### PR TITLE
Fix up install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
+from __future__ import print_function
 import os
+import sys
+import platform
 from setuptools import setup
+from distutils.version import StrictVersion
 
-# Utility function to read the README file.
-
+if StrictVersion(platform.python_version()) < StrictVersion('3.4.3'):
+    print('pysystemtrade requires Python 3.4.3 or later. Exiting.', file=sys.stderr)
+    sys.exit(1)
 
 def read(fname):
+    '''Utility function to read the README file.'''
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
@@ -18,8 +24,8 @@ setup(
     url="http://qoppac.blogspot.co.uk/p/pysystemtrade.html",
     packages=['examples', 'syscore', 'sysdata', 'systems', 'syssims'],
     long_description=read('README.md'),
-    install_requires=["pandas >= 0.17.0", "numpy >= 1.10.1", "python >= 3.4.3", "matlotplib > 1.4.3",
-                      "yaml > 3.11"],
+    install_requires=["pandas >= 0.17.0", "numpy >= 1.10.1", 
+        "matplotlib > 1.4.3", "PyYAML>=3.11", "scipy>=0.17"],
     extras_require=dict(),
     include_package_data=True
 )


### PR DESCRIPTION
Also, Python isn't a package so we can't say "python>=3.4.3" there so we check
`platform.python_version()` in the setup script and bail there.

PyYAML 3.11 is the latest version so we can't depend on `> 3.11`.

scipy is also a dependency.