### PR TITLE
Continuous integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
+[run]
 omit =
     */test_*
     *__init__.py
@@ -5,7 +6,6 @@ omit =
     */.virtualenvs/*
     test/*
 
-[paths]
 source = 
     examples/
     syscore/

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,23 @@
+omit =
+    */test_*
+    *__init__.py
+    */.tox/*
+    */.virtualenvs/*
+    test/*
+
+[paths]
+source = 
+    examples/
+    syscore/
+    syslogdiag/
+    syssims/
+    systems/
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    raise AssertionError
+    if 0:
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,13 @@
 __pycache__
 *.egg-info
 .ipynb_checkpoints
+*.pyc
+*.pyo
+.tox
+dist
+build
 private
+
+# Coverage reports
+.coverage
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 sudo: false
 language: python
 
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.6
+      env: TOX_ENV=py36
 
 install:
-    - pip install tox
+  - pip install tox
 
 script:
-    - tox
+  - tox -e "${TOX_ENV}"
 
-branches:
-
-notifications:
-  email: false
+after_success:
+  - coverage combine
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: python
+
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+install:
+    - pip install tox
+
+script:
+    - tox
+
+branches:
+
+notifications:
+  email: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include LICENSE
+graft examples
+graft sysdata

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     tests_requires=['nose'],
     test_suite='nose.collect',
     extras_require=dict(),
-    test_requires=['pytest', 'coverage', 'pytest-cov'],
+    test_suite='nose.collector',
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,12 @@ setup(
     license="GNU GPL v3",
     keywords="systematic trading interactive brokers",
     url="http://qoppac.blogspot.co.uk/p/pysystemtrade.html",
-    packages=find_packages(),
+    packages=find_packages() + ['systems'],
     long_description=read('README.md'),
     install_requires=["pandas >= 0.19.0", "numpy >= 1.10.1",
                       "matplotlib > 1.4.3", "PyYAML>=3.11", "scipy>=0.17"],
+    tests_requires=['nose'],
+    test_suite='nose.collect',
     extras_require=dict(),
     include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     install_requires=["pandas >= 0.19.0", "numpy >= 1.10.1",
                       "matplotlib > 1.4.3", "PyYAML>=3.11", "scipy>=0.17"],
     tests_requires=['nose'],
-    test_suite='nose.collect',
     extras_require=dict(),
     test_suite='nose.collector',
     include_package_data=True

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
     tests_requires=['nose'],
     test_suite='nose.collect',
     extras_require=dict(),
+    test_requires=['pytest', 'coverage', 'pytest-cov'],
     include_package_data=True
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist=py36
+
+[testenv]
+commands=nosetests
+deps=nose
+    pandas>=0.19.0
+    numpy>=1.10.1
+    matplotlib>1.4.3
+    PyYAML>=3.11
+    scipy>=0.17

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,14 @@
 [tox]
-envlist=py36
+envlist = py36
 
 [testenv]
-commands=nosetests
-deps=nose
-    pandas>=0.19.0
-    numpy>=1.10.1
-    matplotlib>1.4.3
-    PyYAML>=3.11
-    scipy>=0.17
+commands = py.test --cov-conf=.coveragerc --junit-xml=junit-{envname}.xml
+deps =
+    pytest
+    pytest-cov
+
+    pandas >=0.19.0
+    numpy >= 1.10.1
+    matplotlib > 1.4.3
+    PyYAML >= 3.11
+    scipy >= 0.17

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     #pytest
     #pytest-cov
     nose
+    coverage
     pandas>=0.19.0
     numpy>= 1.10.1
     matplotlib>=1.4.3

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ deps =
     matplotlib > 1.4.3
     PyYAML >= 3.11
     scipy >= 0.17
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
-envlist = py36
+envlist = py{35,36}
 
 [testenv]
-commands = py.test --cov-conf=.coveragerc --junit-xml=junit-{envname}.xml
+#commands = py.test --cov-conf=.coveragerc --junit-xml=junit-{envname}.xml
+commands = nosetests
 deps =
-    pytest
-    pytest-cov
-
-    pandas >=0.19.0
-    numpy >= 1.10.1
-    matplotlib > 1.4.3
-    PyYAML >= 3.11
-    scipy >= 0.17
+    #pytest
+    #pytest-cov
+    nose
+    pandas>=0.19.0
+    numpy>= 1.10.1
+    matplotlib>=1.4.3
+    PyYAML>=3.11
+    scipy>=0.17
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,10 @@
 envlist = py{35,36}
 
 [testenv]
-#commands = py.test --cov-conf=.coveragerc --junit-xml=junit-{envname}.xml
-commands = nosetests
+commands = 
+    coverage run -m nose
+    coverage report
 deps =
-    #pytest
-    #pytest-cov
     nose
     coverage
     pandas>=0.19.0


### PR DESCRIPTION
This is an initial cut to get pysystemtrade working with Travis-ci.

This includes a `tox.ini` which lets you run the test suite in a fresh virtualenv as well as a `.travis.yml`

To get this working, I used nose and coverage as opposed to pytest which you were already using. 

Example results are [here](https://travis-ci.org/ehiggs/pysystemtrade). If the tests passed they should also give a coverage report. You can do this manually as follows:

```
$ coverage run -m nose
# ... waiting....
$ coverage report
Name                                                           Stmts   Miss  Cover
----------------------------------------------------------------------------------
examples/smallaccountsize/diversification_plots.py                24     24     0%
examples/smallaccountsize/generatesystems.py                      39     39     0%
examples/smallaccountsize/instrument_list/instrument_list.py      67     67     0%
examples/smallaccountsize/roundingeffects.py                     127    127     0%
syscore/accounting.py                                            499    404    19%
syscore/algos.py                                                  79     47    41%
syscore/capital.py                                                23     23     0%
syscore/correlations.py                                           87      7    92%
syscore/dateutils.py                                              66     10    85%
syscore/divmultipliers.py                                         26     26     0%
syscore/fileutils.py                                              24      0   100%
syscore/genutils.py                                               38     23    39%
syscore/objects.py                                                33      8    76%
syscore/optimisation.py                                          339    339     0%
syscore/pdutils.py                                                69     18    74%
syscore/tests/test.py                                              2      0   100%
syslogdiag/log.py                                                 72     17    76%
systems/account.py                                               474    324    32%
systems/basesystem.py                                            187     41    78%
systems/defaults.py                                                9      0   100%
systems/forecast_combine.py                                      269    154    43%
systems/forecast_scale_cap.py                                     92     18    80%
systems/forecasting.py                                           115     48    58%
systems/futures/rawdata.py                                        56      6    89%
systems/portfolio.py                                             234    196    16%
systems/positionsizing.py                                        100     77    23%
systems/provided/example/rules.py                                 14      5    64%
systems/provided/futures_chapter15/basesystem.py                  19      0   100%
systems/provided/futures_chapter15/rules.py                       12      4    67%
systems/rawdata.py                                                57     21    63%
systems/stage.py                                                  10      1    90%
systems/tests/testdata.py                                         78      0   100%
systems/tests/testfuturesrawdata.py                               12      0   100%
----------------------------------------------------------------------------------
TOTAL                                                           3352   2074    38%
```

If this all goes well, then we can update this to upload a report to [coveralls.io](https://coveralls.io/) and you can get a nice little green badge saying how the CI passed and the code coverage is some %.

My individual commits are messy.. feel free to squash merge if github does that. :)