### PR TITLE
add static tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=read('README.md'),
     install_requires=["pandas >= 0.19.0", "numpy >= 1.10.1",
                       "matplotlib > 1.4.3", "PyYAML>=3.11", "scipy>=0.17"],
-    tests_requires=['nose'],
+    tests_requires=['nose', 'flake8'],
     extras_require=dict(),
     test_suite='nose.collector',
     include_package_data=True

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,14 @@
+import subprocess
+import os
+
+
+THIS_DIR = os.path.dirname(__file__)
+MOD_DIR = os.path.join(THIS_DIR, '..')
+
+
+def test_flake8():
+    retcode = subprocess.call(['flake8',
+                               '--ignore=E123,E125,E126,E128,E711',
+                               '--exclude=__version__.py',
+                               MOD_DIR])
+    assert retcode == 0


### PR DESCRIPTION
static checking (e.g. unused imports, pep8)
lots of failures mainly due to line length, IMO it makes code more readable to stick to this pep8