### PR TITLE
the print message for get_forecast_scalar (line 78) was erroring out

### DIFF
--- a/examples/introduction/simplesystem.py
+++ b/examples/introduction/simplesystem.py
@@ -74,6 +74,7 @@ my_config.use_forecast_scale_estimates = True
 
 fcs = ForecastScaleCap()
 my_system = System([fcs, my_rules], data, my_config)
+my_config.forecast_scalar_estimate["pool_instruments"] = False
 print(
     my_system.forecastScaleCap.get_forecast_scalar("EDOLLAR", "ewmac32").tail(
         5))


### PR DESCRIPTION
because it looks like for that method you need either both a combined
forecast and pool instruments, or neither.
Not sure this is the best fix or if moving these calls to after the Combiner object is created below is better.
but now at least it doesn't error out and terminate.