### PR TITLE
add git url to requirements for automatic install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ numpy>=1.13.3
 scipy>=1.0.0
 quandl>=3.3.0
 pymongo>=3.6.0
-git+//github.com/manahl/arctic.git
+git+git://github.com/manahl/arctic.git


### PR DESCRIPTION
With this added you can run ``pip install -r requirements.txt`` to install the prereqs.