### PR TITLE
Modified cost calc in pandl_for_instrument to include turnover

### DIFF
--- a/systems/account.py
+++ b/systems/account.py
@@ -172,8 +172,7 @@ class _AccountCosts(_AccountInput):
 
         SR_cost_per_turnover = self.get_SR_cost(instrument_code)
 
-        turnover_for_SR = self.subsystem_turnover(
-            instrument_code, roundpositions=roundpositions)
+        turnover_for_SR = self.subsystem_turnover(instrument_code)
         SR_cost = SR_cost_per_turnover * turnover_for_SR
 
         return SR_cost
@@ -630,6 +629,10 @@ class _AccountInstruments(_AccountInstrumentForecast):
         ann_risk_target = self.get_ann_risk_target()
 
         (SR_cost, cash_costs) = self.get_costs(instrument_code)
+        if SR_cost is not None:
+            turnover_for_SR = self.instrument_turnover(
+                instrument_code, roundpositions=roundpositions)
+            SR_cost = SR_cost * turnover_for_SR
 
         instr_pandl = accountCurve(
             price,
@@ -648,9 +651,6 @@ class _AccountInstruments(_AccountInstrumentForecast):
             # Note that SR cost is done as a proportion of capital
             # Since we're only using part of the capital we need to correct
             # for this
-            turnover_for_SR = self.instrument_turnover(
-                instrument_code, roundpositions=roundpositions)
-            SR_cost = SR_cost * turnover_for_SR
             weighting = self.get_instrument_scaling_factor(instrument_code)
             apply_weight_to_costs_only = True
 


### PR DESCRIPTION
Hi Rob,
I believe there is an error in cost calculations whereby the turnover of the instrument was being calculated but not actually used. This resulted in overstated performance of net returns.

As an aside; I also feel the recalculation of the accountCurve with weighting is unnecessary, as it could just be passed in when first instantiated. However, I haven't changed this as I'm not fully aware of the reasoning for the current approach.

P.S. Great repo and books. :)

Kind regards,
Mark.