### PR TITLE
Fixed bug calculating which contract should be held on a given date

### DIFF
--- a/sysdata/futures/rolls.py
+++ b/sysdata/futures/rolls.py
@@ -354,7 +354,14 @@ class rollParameters(object):
         # first held contract after current date
         roll_cycle = getattr(self, rollcycle_name)
 
-        adjusted_date = reference_date + pd.DateOffset(days = -self.roll_offset_day + self.approx_expiry_offset)
+        # adjusted_date: some date before the first day of the nominal contract month we want to hold on
+        # reference_date (and after the first day of the nominal contract month of the previously held contract)
+        #
+        # roll_offset_day: the number of days to roll before (-) or after (+) the contract expiry date
+        #
+        # approx_expiry_offset: the (approximate) number of days before (-) or after(+) the first day of the nominal
+        # contract month of the contract expiration date
+        adjusted_date = reference_date - pd.DateOffset(days=self.roll_offset_day + self.approx_expiry_offset)
 
         relevant_year_int, relevant_month_int = roll_cycle.yearmonth_inrollcycle_after_date(adjusted_date)
 


### PR DESCRIPTION
I'll do my best to explain this clearly, but I probably won't do a great job.

In your [documentation](https://github.com/robcarver17/pysystemtrade/blob/master/docs/futures.md#roll-parameter-configuration), you define roll_offset_days as relative to the contract expiry, and expiry offset as relative to the first day of the (nominal) contract month.

However, in [rollParameters._approx_first_contractDate_at_date](https://github.com/robcarver17/pysystemtrade/blob/master/sysdata/futures/rolls.py), you have opposite signs on these two values.  The appropriate signs should be set in [rollconfig.csv](https://github.com/robcarver17/pysystemtrade/blob/master/sysinit/futures/config/rollconfig.csv), and the calculation in this method should simply add the two offsets then push the reference date back by that number of days.

Unfortunately, it looks like at least some of your roll_offset_days in [rollconfig.csv](https://github.com/robcarver17/pysystemtrade/blob/master/sysinit/futures/config/rollconfig.csv) are set in order to get the desired roll date using the incorrect calculation.  Which means if you change the calculation, you'll also have to change your roll config.  I thought it would be a bit presumptuous to change your roll config in a pull request, so I didn't include that.

For example, take a look at COPPER.  You have an expiry offset of 27 days, and roll offset of -5.  Using your definition of the roll offset, that is impossible. IB will close your position for you long before 5 days prior to expiry.  But looking in the roll calendars, I can see that you are actually rolling about 32 days (27 + 5) before expiry.

Sorry for the long-winded explanation.  Let me know if you need additional clarification.

