### PR TITLE
fix(syscore.algos): use floored vol where applicable

### DIFF
--- a/syscore/algos.py
+++ b/syscore/algos.py
@@ -175,7 +175,7 @@ def robust_vol_calc(x,
         vol_forward_fill = vol_floored.fillna(method = "ffill")
         vol_backfilled = vol_forward_fill.fillna(method = "bfill")
     else:
-        vol_backfilled = vol
+        vol_backfilled = vol_floored
 
     return vol_backfilled
 


### PR DESCRIPTION
This commit ensures that we use the floored volatility when the
backfilling is disabled (which is the most common usage).