### PR TITLE
Fixed bug exception message from previous commit

### DIFF
--- a/syscore/dateutils.py
+++ b/syscore/dateutils.py
@@ -102,8 +102,8 @@ def expiry_date(expiry_ident):
         expiry_date = expiry_ident
 
     else:
-        raise Exception("expiry_ident needs to be a string with 6 or 8 digits, a datetime, or a date; "
-                        "actual type: " + type(expiry_ident) + "; value: " + str(expiry_ident))
+        raise Exception("expiry_ident needs to be a string with 6 or 8 digits, a datetime, or a date;"
+                        f" type={type(expiry_ident)}, value={expiry_ident}")
 
     # 'Natural' form is datetime
     return expiry_date


### PR DESCRIPTION
My bad.

Can't concatenate type(x) to a string using +.  Would have to use + str(type(x)).  But f"..." is nicer.