### PR TITLE
Fixed command name for starting MongoDB

### DIFF
--- a/sysproduction/linux/crontab
+++ b/sysproduction/linux/crontab
@@ -7,4 +7,5 @@
 #
 0 6  * * 1-5 $SCRIPT_PATH/updatefxprices  >> $ECHO_PATH/updatefxprices.echo 2>&1
 #
-@reboot mongodb --dbpath $MONGO_DATA
+# Note: $MONGO_DATA must be accessible at boot; this won't work if it's in an encrypted home folder
+@reboot mongod --dbpath $MONGO_DATA


### PR DESCRIPTION
I also added a comment about encrypted home folders, which took me a while to figure out.  You might want to add a note about this to the documentation.  

Any cron tasks that reference the user's home folder would have the same problem, but tasks run on reboot are guaranteed to fail because they _always_ run before the user has logged in.