### PR TITLE
Fixed ib-insync requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ scipy>=1.0.0
 quandl>=3.3.0
 pymongo>=3.6.0
 arctic>=1.62.0
-ib_insync>=0.9.59
+ib-insync>=0.9.59


### PR DESCRIPTION
I had to use a hyphen instead of an underscore for the module to be recognized by my IDE (PyCharm); however, I see that the docs refer to it with an underscore.

The package name on pypi uses a hyphen:  https://pypi.org/project/ib-insync/0.9.59/

pip seems to work either way