### PR TITLE
Fixed minor issue with position buffers

### DIFF
--- a/systems/portfolio.py
+++ b/systems/portfolio.py
@@ -669,9 +669,9 @@ class Portfolios(_PortfoliosCalculateIDM, _PortfoliosCalculateWeights):
 
         position = self.get_notional_position(instrument_code)
 
-        top_position = position + buffer.ffill()
+        top_position = position.ffill() + buffer.ffill()
 
-        bottom_position = position - buffer.ffill()
+        bottom_position = position.ffill() - buffer.ffill()
 
         pos_buffers = pd.concat([top_position, bottom_position], axis=1)
         pos_buffers.columns = ["top_pos", "bot_pos"]


### PR DESCRIPTION
Depending on the time of day, I might have today's data for some instruments, but only yesterday's data for others.

When this happens, get_notional_position returns a DataFrame with a nan row for today, which results in pos_buffers also ending with a nan row.  This solves that problem.

It might be better to do this in get_notional_position, but doing it here seemed less likely to have surprising consequences.  In any case, I don't think it does any harm.