### PR TITLE
Correct misleading log entries

### DIFF
--- a/sysexecution/strategies/classic_buffered_positions.py
+++ b/sysexecution/strategies/classic_buffered_positions.py
@@ -73,14 +73,14 @@ def trade_given_optimal_and_actual_positions(data, strategy_name, instrument_cod
     log = data.log.setup(strategy_name = strategy_name, instrument_code = instrument_code)
     upper_positions, lower_positions,  reference_prices, reference_contracts, ref_dates = optimal_positions
 
-    upper_for_instrument = upper_positions[instrument_code]
-    lower_for_instrument = lower_positions[instrument_code]
+    upper_for_instrument = round(upper_positions[instrument_code])
+    lower_for_instrument = round(lower_positions[instrument_code])
     actual_for_instrument = actual_positions.get(instrument_code, 0.0)
 
     if actual_for_instrument<lower_for_instrument:
-        required_position = round(lower_for_instrument)
+        required_position = lower_for_instrument
     elif actual_for_instrument>upper_for_instrument:
-        required_position = round(upper_for_instrument)
+        required_position = upper_for_instrument
     else:
         required_position = actual_for_instrument
 


### PR DESCRIPTION
The logic is doing the right thing, but the log entries show the truncated values instead of the rounded ones.  This results in misleading log entries.

For example, if upper was 2.8, lower was 1.0, and actual was 3, the log entry will be:

Trade 0 Upper 2 Lower 1 Actual 3

That makes it look like there should have been a trade of -1.

You could instead use %f placeholders for upper & lower in the log message if you don't want the rounding.