### PR TITLE
Bug fix for commission

### DIFF
--- a/sysproduction/data/broker.py
+++ b/sysproduction/data/broker.py
@@ -151,7 +151,10 @@ class dataBroker(object):
         """
 
         currency_data = currencyData(self.data)
-        base_values = [currency_data.currency_value_in_base(ccy_value) for ccy_value in broker_order.commission]
+        if isinstance(broker_order.commission, float):
+            base_values = [broker_order.commission]
+        else:
+            base_values = [currency_data.currency_value_in_base(ccy_value) for ccy_value in broker_order.commission]
 
         commission = sum(base_values)
         broker_order.commission = commission


### PR DESCRIPTION
So...this probably isn't the best solution, but it works in a pinch.  A better solution would be to avoid having commission attributes of different data types.  It's possible that this is due to not calling a `super().__init__` method somewhere, but I haven't looked into it that deeply.