### PR TITLE
Fixed quantity issue on filled broker orders

### DIFF
--- a/sysbrokers/IB/ibOrders.py
+++ b/sysbrokers/IB/ibOrders.py
@@ -449,7 +449,7 @@ def extract_order_info(trade_to_process):
     limit_price = order.lmtPrice
     order_sign = sign_from_BS(order.action)
     order_type = resolve_order_type(order.orderType)
-    remain_qty = order.totalQuantity
+    remain_qty = trade_to_process.remaining()
 
     orderInfo = namedtuple('orderInfo', ['account',  'perm_id', 'limit_price', 'order_sign', 'type',
                                          'remain_qty', 'order_object'])


### PR DESCRIPTION
Problem: 
When getting a broker order from IB that is filled (or partially filled), the quantity is set to the SUM of the original quantity + the filled quantity

Fix:
To get the actual remaining quantity, you need to use the Trade object's remaining() method. This would be more appropriate for the extract_trade_info function, but that would touch a lot of other code, so I'll leave that up to you if you want to do this another way.