### PR TITLE
Fixed bug in stack hander

### DIFF
--- a/sysexecution/stack_handler/completed_orders.py
+++ b/sysexecution/stack_handler/completed_orders.py
@@ -9,7 +9,7 @@ class stackHandlerForCompletions(stackHandlerCore):
 
 
     def handle_completed_orders(self, allow_partial_completions = False,
-                                allow_zero_completions = True):
+                                allow_zero_completions = False):
         list_of_completed_instrument_orders = \
             self.instrument_stack.list_of_completed_orders(allow_partial_completions = allow_partial_completions,
                                                            allow_zero_completions = allow_zero_completions)


### PR DESCRIPTION
I'm pretty sure you only want to cancel unfilled orders when this is called from the end-of-day cleanup (which already passes True).

As-is, you might not notice a problem with market orders, but would definitely be a problem with limit or anything else that isn't immediately executed.