### PR TITLE
Fixed log msg syntax error in stack handler

### DIFF
--- a/sysexecution/stack_handler/stackHandlerCore.py
+++ b/sysexecution/stack_handler/stackHandlerCore.py
@@ -151,8 +151,8 @@ class stackHandlerCore(object):
         revised_order = proposed_order.change_trade_size_proportionally(possible_trade_size)
 
         if revised_order.trade!=proposed_order.trade:
-            log.msg("%s/%s trade change from %s to %s because of trade limits" \
-                         % (strategy_name, instrument_code, str(proposed_order.trade), str(revised_order.trade)))
+            log.msg("%s/%s trade change from %s to %s because of trade limits"
+                    % strategy_name, instrument_code, str(proposed_order.trade), str(revised_order.trade))
 
         return revised_order
 


### PR DESCRIPTION
Format string arguments shouldn't be wrapped in parentheses.

Also, I hope my pull requests aren't annoying you.  I try to only do them for things that are clearly bugs, without making too many assumptions about how you intend things to work.