### PR TITLE
Fixed apparent bug in system_cache.py

### DIFF
--- a/systems/system_cache.py
+++ b/systems/system_cache.py
@@ -43,7 +43,7 @@ class cacheRef(object):
         self.keyname = keyname
 
     def __repr__(self):
-        if self.keyname is "":
+        if self.keyname == "":
             keystring = ""
         else:
             keystring = "[%s] " % self.keyname
@@ -211,7 +211,7 @@ class systemCache(dict):
         pickable_cache_refs = self._get_pickable_items()
 
         cache_to_pickle = self.partial_cache(pickable_cache_refs)
-        cache_to_pickle_as_dict = self.as_dict()
+        cache_to_pickle_as_dict = cache_to_pickle.as_dict()
 
         with open(filename, "wb+") as fhandle:
             pickle.dump(cache_to_pickle_as_dict, fhandle)


### PR DESCRIPTION
I'm assuming this is a bug, since you go to the effort to populate the variable, but don't use it; also I'm not able to pickle successfully without this change.

And, somewhat related, you probably should add the config for "load_backtests" to the provided defaults.