### PR TITLE
changed class call for data to conform to refactoring

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -721,7 +721,7 @@ You can create your own directory for .csv files. For example supposed you wante
 `pysystemtrade/private/system_name/adjusted_price_data'. Here is how you'd use it:
 
 ```python
-from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
 from systems.provided.futures_chapter15.basesystem import futures_system
 
 data=csvFuturesSimData(datapath_dict=dict(adjusted_prices = "private.system_name.adjusted_price_data"))
@@ -821,7 +821,7 @@ You can import and use data objects directly:
 used as an example.*
 
 ```python
-from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
 
 data=csvFuturesSimData()
 
@@ -862,21 +862,21 @@ should omit the system eg `data.get_raw_price`)
 The `csvFuturesSimData` object works like this:
 
 ```python
-from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
 
 ## with the default folders
 data=csvFuturesData()
 
 ## OR with different folders, by providing a dict containing the folder(s) to use
-data=csvFuturesData(datapath_dict = dict(key_name = "pathtodata.with.dots")) 
+data=csvFuturesData(datapath_dict = dict(key_name = "pathtodata.with.dots"))
 
-# Permissible key names are 'spot_fx_data' (FX prices), 'multiple_price_data' (for carry and forward prices), 
-# 'adjusted_prices' and 'config_data' (configuration and costs). 
+# Permissible key names are 'spot_fx_data' (FX prices), 'multiple_price_data' (for carry and forward prices),
+# 'adjusted_prices' and 'config_data' (configuration and costs).
 # If a keyname is not present then the system defaults will be used
 
 # An example to override with FX data stored in /psystemtrade/private/data/fxdata/:
 
-data=csvFuturesSimData(datapath_dict = dict(spot_fx_data="private.data.fxdata")) 
+data=csvFuturesSimData(datapath_dict = dict(spot_fx_data="private.data.fxdata"))
 
 # WARNING: Do not store multiple_price_data and adjusted_price_data in the same directory
 #          They use the same file names!
@@ -914,10 +914,10 @@ we're trading in (i.e. for a UK investor you'd need a `GBPUSDfx.csv` file). If
 cross rate files are available they will be used; otherwise the USD rates will
 be used to work out implied cross rates.
 
-See data in subdirectories [pysystemtrade/data/futures](/data/futures) for files you can modify: 
+See data in subdirectories [pysystemtrade/data/futures](/data/futures) for files you can modify:
 
 - [adjusted prices](/data/futures/adjusted_prices_csv),
-- [configuration and costs](/data/futures/csvconfig), 
+- [configuration and costs](/data/futures/csvconfig),
 - [Futures specific carry and forward prices](/data/futures/multiple_prices_csv)
 - [Spot FX prices](/data/futures/fx_prices_csv)
 
@@ -929,7 +929,7 @@ For more information see the [futures data document](/docs/futures.md#csvFutures
 
 This is a simData object which gets it's data out of [Mongo DB](https://mongodb.com) (static) and [Arctic](https://github.com/manahl/arctic) (time series) (*Yes the class name should include both terms. Yes I shortened it so it isn't ridiculously long, and most of the interesting stuff comes from Arctic*). It is better for live trading.
 
-For production code, and storing large amounts of data (eg for individual futures contracts) we probably need something more robust than .csv files. 
+For production code, and storing large amounts of data (eg for individual futures contracts) we probably need something more robust than .csv files.
 [MongoDB](https://mongodb.com) is a no-sql database which is rather fashionable at the moment, though the main reason I selected it for this purpose is that it is used by Arctic. [Arctic](https://github.com/manahl/arctic) is a superb open source time series database which sits on top of Mongo DB) and provides straightforward and fast storage of pandas DataFrames. It was created by my former colleagues at [Man AHL](https://www.ahl.com/) (in fact I beta tested a very early version of Arctic), and then very generously released as open source.
 
 There is more detail on this in the [futures data documentation](/docs/futures.md): [Mongo DB](/docs/futures.md#mongoDB) and [Arctic](/docs/futures.md#arctic).
@@ -946,7 +946,7 @@ You can do this from scratch, as per the ['futures data workflow'](/docs/futures
 - [Multiple prices](/sysinit/futures/repocsv_multiple_prices.py)
 - [Spot FX prices](/sysinit/futures/repocsv_spotfx_prices.py)
 
-Of course it's also possible to mix these two methods. 
+Of course it's also possible to mix these two methods.
 
 ##### Using arcticFuturesSimData
 
@@ -976,7 +976,7 @@ You should be familiar with the python object orientated idiom before reading
 this section.
 
 The [`simData()`](/sysdata/data.py) object is the base class for data used in simulations. From that we
-inherit data type specific classes such as those 
+inherit data type specific classes such as those
 [for futures](/sysdata/futures/futuresDataForSim.py) object. These in turn are inherited from
 for specific data sources, such as for csv files: [csvFuturesSimData()](/sysdata/csv/csv_sim_futures_data.py).
 
@@ -1981,7 +1981,7 @@ Then it's a case of creating the python function. Here is an extract from the
 ```python
 ## We probably need these to get our data
 
-from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
 from sysdata.configdata import Config
 
 ## We now import all the stages we need
@@ -2460,7 +2460,7 @@ definition, but if included here will be used instead of the separate
 
 All the items in the `data` list passed to a trading rule are string references to methods in the system object that (usually) take a single argument, the instrument code. In theory these could be anywhere in the system object, but by convention they should only be in `system.rawdata` or `system.data` (if they are in stages that call the rules stage, you will get infinite recursion and things will break), with perhaps occasional reference to `system.get_instrument_list()`. The advantage of using methods in `rawdata` is that these are cached, and can be re-used. It's strongly recommended that you use methods in `rawdata` for trading rules.
 
-What if you want to pass arguments to the data method? For example, you might want to pre-calculate the moving averages of different lengths in `rawdata` and then reuse them to save time. Or you might want to calculate skew over a given time period for all markets and then take a cross sectional average to use in a relative value rule. 
+What if you want to pass arguments to the data method? For example, you might want to pre-calculate the moving averages of different lengths in `rawdata` and then reuse them to save time. Or you might want to calculate skew over a given time period for all markets and then take a cross sectional average to use in a relative value rule.
 
 We can do this by passing special kinds of `other_args` which are pre-fixed with underscores, eg "_". If an element in the other_ags dictionary has no underscores, then it is passed to the trading rule function as a keyword argument. If it has one leading underscore eg "_argname", then it is passed to the first method in the data list as a keyword argument. If it has two underscores eg "__argname", then it is passed to the second method in the data list, and so on.
 
@@ -2487,7 +2487,7 @@ def new_ewma(fast_ewma, slow_ewma, vol, multiplier=1):
     raw_ewmac = fast_ewma - slow_ewma
 
     raw_ewmac = raw_ewmac * multiplier
-    
+
     return raw_ewmac / vol.ffill()
 
 # Now we define our first trading rule. Notice that data gets two kinds of moving average, but the first one will have span 2 and the second span 8
@@ -2524,7 +2524,7 @@ a look at an incomplete version of the pre-baked chapter 15 futures system.
 ```python
 ## We probably need these to get our data
 
-from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
 from sysdata.configdata import Config
 from systems.basesystem import System
 
@@ -2584,7 +2584,7 @@ understanding).
 5. When the method `get_trading_rules` is called it looks to see if there is a *processed* dict of trading rules
 6. The first time the method `get_trading_rules` is called there won't be a processed list. So it looks for something to process
 7. First it will look to see if anything was passed when the instance rules of the `Rules()` class was created
-8. Since we didn't pass anything instead it processes what it finds in `system.config.trading_rules` - a nested dict, keynames rule variation names. 
+8. Since we didn't pass anything instead it processes what it finds in `system.config.trading_rules` - a nested dict, keynames rule variation names.
 9. The `Rules` instance now has processed rule names in the form of a dict, keynames rule variation names, each element containing a valid `TradingRule` object
 
 
@@ -3009,7 +3009,7 @@ sysdiag.forecast_mapping()
 
 Parameters are specified by market as follows:
 
-YAML: 
+YAML:
 ```
 forecast_mapping:
   AEX:
@@ -3752,11 +3752,11 @@ from syscore.fileutils import get_resolved_pathname, get_filename_for_package
 ### Windows (note use of double backslash in str) Make sure you include the initial backslash, or will be treated as relative format
 get_filename_for_package("\\home\\rob\\file.csv")
 
-### Unix. Make sure you include the initial forward slash, 
+### Unix. Make sure you include the initial forward slash,
 get_filename_for_package("/home/rob/file.csv")
 
-## Relative format to find a file in the installed pysystemtrade 
-### Dot format. Notice there is no initial 'dot' and we don't need to include 'pysystemtrade' 
+## Relative format to find a file in the installed pysystemtrade
+### Dot format. Notice there is no initial 'dot' and we don't need to include 'pysystemtrade'
 get_filename_for_package("syscore.tests.pricedata.csv")
 
 # Specify the path and filename separately
@@ -3770,7 +3770,7 @@ get_resolved_pathname("\\home\\rob")
 get_resolved_pathname("syscore.tests")
 
 ## DON'T USE THESE:-
-### It's possible to use Unix or Windows for relative filenames, but I prefer not to, so there is a clearer disctinction between absolute and relative. 
+### It's possible to use Unix or Windows for relative filenames, but I prefer not to, so there is a clearer disctinction between absolute and relative.
 ### However this works:
 get_filename_for_package("syscore/tests/pricedata.csv")
 
@@ -3791,7 +3791,7 @@ These functions are used internally whenever a file name is passed in, so feel f
 ### Absolute: Unix.
 "/home/rob/file.csv"
 
-## Relative: Dot format to find a file in the installed pysystemtrade 
+## Relative: Dot format to find a file in the installed pysystemtrade
 "syscore.tests.pricedata.csv"
 ```
 
@@ -3854,7 +3854,7 @@ method is called, it will typically know one or more of the following:
 - component: other parts of the top level function that have their own loggers
 - currency_code: Currency code (used for fx), format 'GBPUSD'
 - instrument_code: Self explanatory
-- contract_date: Self explanatory, format 'yyyymm' 
+- contract_date: Self explanatory, format 'yyyymm'
 - order_id: Self explanatory, used for live trading
 
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,4 +1,4 @@
- 
+
 
 Here is a whistlestop tour of what pysystemtrade can currently do. You'll probably want to read the [users guide](userguide.md) after this.
 Notice that you will see different results than shown here, as you will be using more up to date data.
@@ -7,10 +7,10 @@ Notice that you will see different results than shown here, as you will be using
 
 (code is [here](/examples/introduction/asimpletradingrule.py) )
 
-As systematic traders we believe that the future will be at least a bit like the past. So first of all we need some past data. In principle past data can come from many places, but to begin with we'll get it from some pre-baked .csv files: 
+As systematic traders we believe that the future will be at least a bit like the past. So first of all we need some past data. In principle past data can come from many places, but to begin with we'll get it from some pre-baked .csv files:
 
 ```python
-from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
 data=csvFuturesSimData()
 data
 ```
@@ -72,7 +72,7 @@ data.get_instrument_raw_carry_data("EDOLLAR").tail(6)
 2016-05-11  98.6675     NaN         201903         201906
 ```
 
-Let's create a simple trading rule. 
+Let's create a simple trading rule.
 
 
 ```python
@@ -81,11 +81,11 @@ import pandas as pd
 from syscore.algos import robust_vol_calc
 
 def calc_ewmac_forecast(price, Lfast, Lslow=None):
-    
-    
+
+
     """
     Calculate the ewmac trading fule forecast, given a price and EWMA speeds Lfast, Lslow and vol_lookback
-    
+
     """
     ## price: This is the stitched price series
     ## We can't use the price of the contract we're trading, or the volatility will be jumpy
@@ -94,15 +94,15 @@ def calc_ewmac_forecast(price, Lfast, Lslow=None):
     price = price.resample("1B").last()
     if Lslow is None:
         Lslow=4*Lfast
-    
+
     ## We don't need to calculate the decay parameter, just use the span directly
-    
+
     fast_ewma=price.ewm(span=Lfast).mean()
     slow_ewma=price.ewm(span=Lslow).mean()
     raw_ewmac=fast_ewma - slow_ewma
-    
+
     vol=robust_vol_calc(price.diff())    
-    
+
     return raw_ewmac / vol
 
 ```
@@ -187,7 +187,7 @@ A full list of stages would include:
 
 1. Preprocessing some raw data (which we don't cover in this introduction)
 2. Running some trading rules over it to generate forecasts
-3. Scaling and capping those forecasts 
+3. Scaling and capping those forecasts
 4. Combining forecasts together
 5. Position sizing
 6. Creating a portfolio of instruments
@@ -196,7 +196,7 @@ A full list of stages would include:
 For now let's start with the simplest possible system, one which contains only a trading rules stage. Let's just setup our environment again:
 
 ```python
-from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
 data=csvFuturesSimData()
 
 from systems.provided.example.rules import ewmac_forecast_with_defaults as ewmac
@@ -266,7 +266,7 @@ ewmac_rule
 ```
 
 ```
-TradingRule; function: <function ewmac_forecast_with_defaults at 0xb734ca4c>, data:  and other_args: 
+TradingRule; function: <function ewmac_forecast_with_defaults at 0xb734ca4c>, data:  and other_args:
 ```
 
 Time to reveal what the mysterious object is. A `TradingRule` contains 3 elements - a function, a list of any data the function needs, and a dict of any other arguments that can be passed to the function. So the function is just the `ewmac` function that we imported earlier, and in this trivial case there is no data, and no arguments. Having no data is fine, because the code assumes that you'd normally want to pass the price of an instrument to a trading rule if you don't tell it otherwise. Furthermore on this occassion having no arguments is also no problem since the ewmac function we're using includes some defaults.
@@ -286,7 +286,7 @@ my_rules.trading_rules()['ewmac32']
 TradingRule; function: <function ewmac_forecast_with_defaults at 0xb7252a4c>, data:  and other_args: Lfast, Lslow
 ```
 
-Again, let's check that `ewmac32` is the same as the `ewmac` we have before (it should be, since 32, 128 are the default arguments for the underlying trading rule function). 
+Again, let's check that `ewmac32` is the same as the `ewmac` we have before (it should be, since 32, 128 are the default arguments for the underlying trading rule function).
 
 ```python
 my_system=System([my_rules], data)
@@ -303,7 +303,7 @@ Freq: B, dtype: float64
 ```
 
 
-Now let's introduce the idea of **config** objects. A `config` or configuration object allows us to control the behaviour of the various stages in the system. 
+Now let's introduce the idea of **config** objects. A `config` or configuration object allows us to control the behaviour of the various stages in the system.
 
 Configuration objects can be created on the fly or by reading in files written in yaml (which we'll talk about below). A configuration object is just a collection of attributes. We create them interactively like so:
 
@@ -314,7 +314,7 @@ my_config
 ```
 
 ```
-Config with elements: 
+Config with elements:
 ## this line intentionally left blank. Apart from this comment of course.
 ```
 
@@ -367,7 +367,7 @@ Freq: B, dtype: float64
 ```
 
 
-Alternatively we can use the fixed values from Appendix B of my book ["Systematic Trading"](http:/www.systematictrading.org). 
+Alternatively we can use the fixed values from Appendix B of my book ["Systematic Trading"](http:/www.systematictrading.org).
 
 
 ```python
@@ -428,7 +428,7 @@ WARNING: No forecast weights  - using equal weights of 0.5000 over all 2 trading
 Freq: B, dtype: float64
 ```
 
-Alternatively you can estimate div. multipliers, and weights. 
+Alternatively you can estimate div. multipliers, and weights.
 
 Note: Since we need to know the performance of different trading rules, we need to include an Accounts stage to calculate these:
 
@@ -437,7 +437,7 @@ from systems.account import Account
 my_account = Account()
 
 ## let's use naive markowitz to get more interesting results...
-my_config.forecast_weight_estimate=dict(method="one_period") 
+my_config.forecast_weight_estimate=dict(method="one_period")
 my_config.use_forecast_weight_estimates=True
 my_config.use_forecast_div_mult_estimates = True
 
@@ -494,7 +494,7 @@ Freq: B, dtype: float64
 
 ```
 
-If you're working through my book you'd know the next stage is deciding what level of risk to target (chapter 9) and position sizing (chapter 10). 
+If you're working through my book you'd know the next stage is deciding what level of risk to target (chapter 9) and position sizing (chapter 10).
 Let's do the position scaling:
 
 ```python
@@ -522,7 +522,7 @@ my_system.positionSize.get_subsystem_position("EDOLLAR").tail(5)
 Freq: B, dtype: float64
 ```
 
-We're almost there. The final stage we need to get positions is to combine everything into a portfolio (chapter 11). 
+We're almost there. The final stage we need to get positions is to combine everything into a portfolio (chapter 11).
 
 We can estimate these:
 
@@ -639,7 +639,7 @@ my_config=Config("systems.provided.example.simplesystemconfig.yaml")
 
 (Notice we don't put filenames in; rather a python style reference within the project)
 
-If you look at the YAML file you'll notice that the trading rule function has been specified as a string `systems.provided.example.rules.ewmac_forecast_with_defaults`. This is because we can't easily create a function in a YAML text file (*we can in theory; but it's quite a bit of work and creates a potential security risk*). Instead we specify where the relevant function can be found in the project directory structure. 
+If you look at the YAML file you'll notice that the trading rule function has been specified as a string `systems.provided.example.rules.ewmac_forecast_with_defaults`. This is because we can't easily create a function in a YAML text file (*we can in theory; but it's quite a bit of work and creates a potential security risk*). Instead we specify where the relevant function can be found in the project directory structure.
 
 Similarly for the ewmac8 rule we've specified a data source `data.daily_prices` which points to `system.data.daily_prices()`. This is the default, which is why we haven't needed to specify it before, and it isn't included in the specification for the ewmac32 rule. Equally we could specify any attribute and method within the system object, as long as it takes the argument `instrument_code`. We can also have a list of data inputs. This means you can configure almost any trading rule quite easily through configuration changes.
 
@@ -647,7 +647,7 @@ Similarly for the ewmac8 rule we've specified a data source `data.daily_prices` 
 
 ## A simple pre-baked system
 
-Normally we wouldn't create a system by adding each stage manually (importing and creating long lists of stage objects). Instead you can use a 'pre baked' system, and then modify it as required. 
+Normally we wouldn't create a system by adding each stage manually (importing and creating long lists of stage objects). Instead you can use a 'pre baked' system, and then modify it as required.
 
 For example here is a pre-baked version of the previous example (code is [here](/examples/introduction/prebakedsystems.py) ):
 
@@ -673,7 +673,7 @@ By default this has loaded the same data and read the config from the same yaml 
 
 ```python
 from sysdata.configdata import Config
-from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
 
 my_config=Config("systems.provided.example.simplesystemconfig.yaml")
 my_data=csvFuturesSimData()


### PR DESCRIPTION
#### Reference issues  PR's
None 
#### What does this implement / fix?
Due to refactoring calls for sim data have changed 
From: 
from sysdata.csv.csv_sim_futures_data import csvFuturesSimData
To: 
from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
Changed in two doc files: 
introduction.md and backtesting.md 
In various examples. 
#### Any other comments 
None 
