### PR TITLE
added starttls to email _send_msg function

### DIFF
--- a/syslogdiag/emailing.py
+++ b/syslogdiag/emailing.py
@@ -78,6 +78,11 @@ def _send_msg(msg):
     # Send the message via our own SMTP server, but don't include the
     # envelope header.
     s = smtplib.SMTP(email_server, 587)
+    # add tls for those using yahoo or gmail. 
+    try:
+        s.starttls()
+    except:
+        pass
     s.login(email_address, email_pwd)
     s.sendmail(me, [you], msg.as_string())
     s.quit()


### PR DESCRIPTION

#### Reference issues PR's

For those using external email servers such as yahoo or gmail, they need TLS.
to prevent the error message : SMTPNotSupportedError(smptlib.SMTPNotSupportedError: SMTP AUTH extension not supported by server
and system emails not being sent...

##### What does this implement / fix?
added code to try and submit starttls() to allow authorisation from the server to send email, with an exception catch in case server does not need TLS.

###### Other comments 
Have no way of testing the exception catch on a server not needing TLS, needs to be tested in such an environment.
The code does work for a setup that does have such a requirement. 

 