### PR TITLE
Fixed error allocating strategy capital

### DIFF
--- a/sysproduction/update_strategy_capital.py
+++ b/sysproduction/update_strategy_capital.py
@@ -52,8 +52,7 @@ class updateStrategyCapital(object):
 def call_allocation_function(data: dataBlob) -> dict:
 
     strategy_allocation_config_dict = get_strategy_allocation_config_dict(data)
-    strategy_allocation_function_str = strategy_allocation_config_dict.pop(
-        "function")
+    strategy_allocation_function_str = strategy_allocation_config_dict["function"]
     strategy_allocation_function = resolve_function(
         strategy_allocation_function_str)
 


### PR DESCRIPTION
Pop is removing the item from the dictionary. So if this method is configured to run more than once, only the first run works.