### PR TITLE
Sharpe and Cash Costs fix

### DIFF
--- a/syscore/accounting.py
+++ b/syscore/accounting.py
@@ -952,7 +952,8 @@ def calc_costs(returns_data, cash_costs, SR_cost, ann_risk):
                 [value_of_pertrade_commission] * len(traded.index),
                 traded.index)
             costs_pertrade = costs_pertrade.reindex(trades_to_use.index)
-
+            # added a fillna(0) to avoid that any Nan affects the sum below.
+            costs_pertrade = costs_pertrade.fillna(0)
         # everything on the trades index, so can do this:s
         costs_instr_ccy = costs_blocks + costs_percentage + costs_pertrade
 

--- a/systems/account.py
+++ b/systems/account.py
@@ -628,9 +628,12 @@ class _AccountInstruments(_AccountInstrumentForecast):
 
         capital = self.get_notional_capital()
         ann_risk_target = self.get_ann_risk_target()
-
+        
         (SR_cost, cash_costs) = self.get_costs(instrument_code)
-
+        # moved turnover multiplcation before accountCurve
+        turnover_for_SR = self.instrument_turnover(
+                instrument_code, roundpositions=roundpositions)
+        SR_cost = SR_cost * turnover_for_SR
 
         instr_pandl = accountCurve(
             price,
@@ -649,9 +652,7 @@ class _AccountInstruments(_AccountInstrumentForecast):
             # Note that SR cost is done as a proportion of capital
             # Since we're only using part of the capital we need to correct
             # for this
-            turnover_for_SR = self.instrument_turnover(
-                instrument_code, roundpositions=roundpositions)
-            SR_cost = SR_cost * turnover_for_SR
+            # moved turnover multiplcation before accountCurve
             weighting = self.get_instrument_scaling_factor(instrument_code)
             apply_weight_to_costs_only = True
 


### PR DESCRIPTION
For cash costs, I have noticed that costs for some instruments were significantly lower than expected. I have found out that it was due to the presence of Nans during re-indexing.

for Sharpe, also I have noticed that costs were underestimated for fast rules in pandl_for_instrument due to turnover not being used (i.e. turnover of 1 for all strategies).
This issue was raised also [here](https://github.com/robcarver17/pysystemtrade/issues/220)