### PR TITLE
Mask mongo credentials

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -684,7 +684,9 @@ You need to specify an IP address (host), and database name when you connect to 
 - Then, variables set in the private `.yaml` configuration file /private/private_config.yaml: mongo_host, mongo_db, mongo_port
 - Finally, default arguments in the [system defaults configuration file](/systems/provided/defaults.yaml): mongo_host, mongo_db, mongo_port
 
-Note that `localhost` is equivalent to `127.0.0.1`, i.e. this machine. Note also that the port number is hard coded in Arctic so you should stick to the default port 27017.
+Note that `localhost` is equivalent to `127.0.0.1`, i.e. this machine. Note also that if you have a non-standard mongo port, you must use the url format for specifying the mongo host, eg
+
+```mongo_host: mongodb://username:p4zzw0rd@localhost:28018```
 
 If your mongoDB is running on your local machine then you can stick with the defaults (assuming you are happy with the database name `production`). If you have different requirements, eg mongo running on another machine or you want a different database name, then you should set them in the private .yaml file. If you have highly bespoke needs, eg you want to use a different database or different host for different types of data, then you will need to add code like this:
 

--- a/sysdata/arctic/arctic_adjusted_prices.py
+++ b/sysdata/arctic/arctic_adjusted_prices.py
@@ -23,12 +23,7 @@ class arcticFuturesAdjustedPricesData(futuresAdjustedPricesData):
 
 
     def __repr__(self):
-        return \
-            "simData connection for adjusted futures prices, arctic %s/%s @ %s " %\
-            (self._arctic.database_name,
-             self._arctic.collection_name,
-             self._arctic.host,
-             )
+        return f"adjusted futures prices, arctic: {repr(self._arctic)}"
 
     @property
     def arctic(self):

--- a/sysdata/arctic/arctic_adjusted_prices.py
+++ b/sysdata/arctic/arctic_adjusted_prices.py
@@ -23,7 +23,7 @@ class arcticFuturesAdjustedPricesData(futuresAdjustedPricesData):
 
 
     def __repr__(self):
-        return f"adjusted futures prices, arctic: {repr(self._arctic)}"
+        return repr(self._arctic)
 
     @property
     def arctic(self):

--- a/sysdata/arctic/arctic_connection.py
+++ b/sysdata/arctic/arctic_connection.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from arctic import Arctic
-from sysdata.mongodb.mongo_connection import mongoDb
+from sysdata.mongodb.mongo_connection import mongoDb, clean_mongo_host
 
 """
 IMPORTANT NOTE: Make sure you have a mongodb running eg mongod --dbpath /home/yourusername/pysystemtrade/data/futures/arctic
@@ -36,11 +36,8 @@ class arcticData(object):
         self.library = self._setup_lib(store, database_name, collection_name)
 
     def __repr__(self):
-        return "Arctic connection: host %s, db name %s, collection %s" % (
-            self.host,
-            self.database_name,
-            self.collection_name,
-        )
+        return f"Arctic connection: host {clean_mongo_host(self.host)}, " \
+               f"db {self.database_name}, collection {self.collection_name}"
 
     def read(self, ident) -> pd.DataFrame:
         item = self.library.read(ident)

--- a/sysdata/arctic/arctic_futures_per_contract_prices.py
+++ b/sysdata/arctic/arctic_futures_per_contract_prices.py
@@ -28,8 +28,8 @@ class arcticFuturesContractPriceData(futuresContractPriceData):
         self._arctic_connection = arcticData(CONTRACT_COLLECTION, mongo_db=mongo_db)
 
     def __repr__(self):
-        return "simData connection for individual futures contracts prices, arctic %s/%s @ %s " % (
-            self._arctic_connection.database_name, self._arctic_connection.collection_name, self._arctic_connection.host)
+        return "arctic storage for individual futures contracts prices, %s " % (
+            repr(self._arctic_connection))
 
     @property
     def arctic_connection(self):

--- a/sysdata/arctic/arctic_futures_per_contract_prices.py
+++ b/sysdata/arctic/arctic_futures_per_contract_prices.py
@@ -28,8 +28,7 @@ class arcticFuturesContractPriceData(futuresContractPriceData):
         self._arctic_connection = arcticData(CONTRACT_COLLECTION, mongo_db=mongo_db)
 
     def __repr__(self):
-        return "arctic storage for individual futures contracts prices, %s " % (
-            repr(self._arctic_connection))
+        return f"futures contract prices, arctic: {repr(self._arctic_connection)}"
 
     @property
     def arctic_connection(self):

--- a/sysdata/arctic/arctic_futures_per_contract_prices.py
+++ b/sysdata/arctic/arctic_futures_per_contract_prices.py
@@ -28,7 +28,7 @@ class arcticFuturesContractPriceData(futuresContractPriceData):
         self._arctic_connection = arcticData(CONTRACT_COLLECTION, mongo_db=mongo_db)
 
     def __repr__(self):
-        return f"futures contract prices, arctic: {repr(self._arctic_connection)}"
+        return repr(self._arctic_connection)
 
     @property
     def arctic_connection(self):

--- a/sysdata/arctic/arctic_multiple_prices.py
+++ b/sysdata/arctic/arctic_multiple_prices.py
@@ -28,13 +28,8 @@ class arcticFuturesMultiplePricesData(futuresMultiplePricesData):
 
         self._arctic = arcticData(MULTIPLE_COLLECTION, mongo_db=mongo_db)
 
-
     def __repr__(self):
-        return             "simData connection for multiple futures prices, arctic %s/%s @ %s " % \
-            (self._arctic.database_name,
-             self._arctic.collection_name,
-             self._arctic.host,
-             )
+        return f"multiple futures prices, arctic: {repr(self._arctic)}"
 
     @property
     def arctic(self):

--- a/sysdata/arctic/arctic_multiple_prices.py
+++ b/sysdata/arctic/arctic_multiple_prices.py
@@ -29,7 +29,7 @@ class arcticFuturesMultiplePricesData(futuresMultiplePricesData):
         self._arctic = arcticData(MULTIPLE_COLLECTION, mongo_db=mongo_db)
 
     def __repr__(self):
-        return f"multiple futures prices, arctic: {repr(self._arctic)}"
+        return repr(self._arctic)
 
     @property
     def arctic(self):

--- a/sysdata/arctic/arctic_spotfx_prices.py
+++ b/sysdata/arctic/arctic_spotfx_prices.py
@@ -21,11 +21,7 @@ class arcticFxPricesData(fxPricesData):
         return self._arctic
 
     def __repr__(self):
-        return "Arctic connection for spotfx prices, %s/%s @ %s " % (
-            self.arctic.database_name,
-            self.arctic.collection_name,
-            self.arctic.host,
-        )
+        return repr(self._arctic)
 
     def get_list_of_fxcodes(self) -> list:
         return self.arctic.get_keynames()

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -36,7 +36,8 @@ ib_idoffset: 100
 # Mongo DB
 mongo_host: 127.0.0.1
 mongo_db: 'production'
-# DO NOT CHANGE THIS VALUE!!!! IT WILL SCREW UP ARCTIC
+# DO NOT CHANGE THIS VALUE!!!! IT WILL SCREW UP ARCTIC. If you need to use a port other than 27017, use the url
+# format for mongo_host, eg mongodb://127.0.0.1:27018
 mongo_port: 27017
 #
 # Needs to be consistent with what you are using in crontab

--- a/sysdata/mongodb/mongo_connection.py
+++ b/sysdata/mongodb/mongo_connection.py
@@ -102,9 +102,8 @@ class mongoDb():
 
     def __repr__(self):
         clean_host = clean_mongo_host(self.host)
-        return "Mongodb database: host %s, port %d, db name %s" % (
+        return "Mongodb database: host %s, db name %s" % (
             clean_host,
-            self.port,
             self.database_name,
         )
 
@@ -140,8 +139,8 @@ class mongoConnection(object):
 
     def __repr__(self):
         clean_host = clean_mongo_host(self.host)
-        return "Mongodb connection: host %s, port %d, db name %s, collection %s" % (
-            clean_host, self.port, self.database_name, self.collection_name, )
+        return "Mongodb connection: host %s, db name %s, collection %s" % (
+            clean_host, self.database_name, self.collection_name, )
 
     def get_indexes(self):
 
@@ -205,7 +204,7 @@ def mongo_clean_ints(dict_to_clean):
 
 def clean_mongo_host(host_string):
     """
-    If the host string is a mongodb connection URL with authentication values, then return just the host part
+    If the host string is a mongodb connection URL with authentication values, then return just the host and port part
     :param host_string
     :return: host name part only
     """

--- a/sysdata/mongodb/mongo_connection.py
+++ b/sysdata/mongodb/mongo_connection.py
@@ -206,7 +206,7 @@ def clean_mongo_host(host_string):
     """
     If the host string is a mongodb connection URL with authentication values, then return just the host and port part
     :param host_string
-    :return: host name part only
+    :return: host and port only
     """
 
     clean_host = host_string

--- a/sysdata/mongodb/mongo_generic.py
+++ b/sysdata/mongodb/mongo_generic.py
@@ -6,6 +6,7 @@ from sysdata.mongodb.mongo_connection import (
     mongoConnection,
     MONGO_ID_KEY,
     mongo_clean_ints,
+    clean_mongo_host
 )
 
 
@@ -45,17 +46,11 @@ class mongoDataWithSingleKey(object):
 
     @property
     def name(self) -> str:
-        mongo_object = self._mongo
-        name = (
-            "mongoData connection for %s, mongodb %s/%s @ %s -p %s " %
-            (mongo_object.collection_name,
-            mongo_object.database_name,
-             mongo_object.collection_name,
-             mongo_object.host,
-             mongo_object.port,
-             ))
+        col = self._mongo.collection_name
+        db = self._mongo.database_name
+        host = clean_mongo_host(self._mongo.host)
 
-        return name
+        return f"mongoData connection for {col}/{db}, {host}"
 
     @property
     def collection(self):

--- a/sysdata/mongodb/tests/test_mongodb.py
+++ b/sysdata/mongodb/tests/test_mongodb.py
@@ -1,0 +1,25 @@
+from sysdata.mongodb.mongo_connection import clean_mongo_host
+
+
+class TestMongoDB:
+
+    def test_hide_password(self):
+
+        # examples from https://docs.mongodb.com/manual/reference/connection-string/
+
+        #host_pattern = re.compile('^(mongodb://)([^:]+):([^@]+)@([^/]+)')
+
+        standalone = "mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin"
+        clean_standalone = clean_mongo_host(standalone)
+        print(clean_standalone)
+        assert 'D1fficultP%40ssw0rd' not in clean_standalone
+
+        replica = "mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017,mongodb1.example.com:27017,mongodb2.example.com:27017/?authSource=admin&replicaSet=myRepl"
+        clean_replica = clean_mongo_host(replica)
+        print(clean_replica)
+        assert 'D1fficultP%40ssw0rd' not in clean_replica
+
+        sharded = "mongodb://myDBReader:D1fficultP%40ssw0rd@mongos0.example.com:27017,mongos1.example.com:27017,mongos2.example.com:27017/?authSource=admin"
+        clean_sharded = clean_mongo_host(sharded)
+        print(clean_sharded)
+        assert 'D1fficultP%40ssw0rd' not in clean_sharded

--- a/sysdata/mongodb/tests/test_mongodb.py
+++ b/sysdata/mongodb/tests/test_mongodb.py
@@ -5,9 +5,27 @@ class TestMongoDB:
 
     def test_hide_password(self):
 
-        # examples from https://docs.mongodb.com/manual/reference/connection-string/
+        # url examples from https://docs.mongodb.com/manual/reference/connection-string/
 
-        #host_pattern = re.compile('^(mongodb://)([^:]+):([^@]+)@([^/]+)')
+        ip = "mongodb://127.0.0.1/production"
+        clean_ip = clean_mongo_host(ip)
+        print(clean_ip)
+        assert clean_ip == ip
+
+        simple = "mongodb://localhost/production"
+        clean_simple = clean_mongo_host(simple)
+        print(clean_simple)
+        assert clean_simple == simple
+
+        simple_pw = "mongodb://myDBReader:D1fficultP%40ssw0rd@localhost/production"
+        clean_simple_pw = clean_mongo_host(simple_pw)
+        print(clean_simple_pw)
+        assert 'D1fficultP%40ssw0rd' not in clean_simple_pw
+
+        simple_port = "mongodb://localhost:28018/production"
+        clean_simple_port = clean_mongo_host(simple_port)
+        print(simple_port)
+        assert clean_simple_port == simple_port
 
         standalone = "mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin"
         clean_standalone = clean_mongo_host(standalone)


### PR DESCRIPTION
The changes in this PR mask the mongo credentials in logs and console output when the mongo host is defined as a URL with embedded credentials, eg

```
mongo_host:  mongodb://user:password@localhost
```

It also updates docs and comments regarding the port for Arctic connections; custom ports work fine with Arctic if the url format is used, eg ```mongodb://localhost:27018```

Going forward it may make sense to simplify the mongo connection properties. The default host could be set as:

```
mongo_host:  mongodb://localhost/production
```

and `mongo_db` and `mongo_port` dropped

