### PR TITLE
fix bounds on roll periods in _calc_roll_date_info

### DIFF
--- a/sysinit/futures/build_multiple_prices_from_raw_data.py
+++ b/sysinit/futures/build_multiple_prices_from_raw_data.py
@@ -106,10 +106,10 @@ def _calc_roll_date_info(roll_calendar_with_roll_index: rollCalendarWithRollInde
     last_roll_date = roll_calendar.index[rolling_row_index - 1]
     next_roll_date = roll_calendar.index[rolling_row_index]
 
-    end_of_roll_period = next_roll_date
-    start_of_roll_period = last_roll_date + pd.DateOffset(
+    end_of_roll_period = next_roll_date - pd.DateOffset(
         seconds=1
     )  # to avoid overlaps
+    start_of_roll_period = last_roll_date
 
     roll_date_info = rollDateInfo(last_roll_date, next_roll_date,
                                   start_of_roll_period, end_of_roll_period,


### PR DESCRIPTION
Hopefully this snippet explains the rationale:

    def _get_current_next_carry_data(roll_date_info: rollDateInfo, contract_date_info: contractAndPriceInfo):
        dict_of_futures_contract_closing_prices = contract_date_info.dict_of_futures_contract_closing_prices
        # contract_date_info.current_contract_str == '20091000'
        # roll_date_info.start_of_roll_period == Timestamp('2009-09-17 23:00:00')
        # roll_date_info.end_of_roll_period == Timestamp('2009-10-19 22:59:59')
        current_price_data =  dict_of_futures_contract_closing_prices[contract_date_info.current_contract_str[roll_date_info.start_of_roll_period:roll_date_info.end_of_roll_period]

Above is from build_multiple_prices_from_raw_data.py with the comments reflecting my change.
Without this change we get:

    def _get_current_next_carry_data(roll_date_info: rollDateInfo, contract_date_info: contractAndPriceInfo):
        dict_of_futures_contract_closing_prices = contract_date_info.dict_of_futures_contract_closing_prices
        # contract_date_info.current_contract_str == '20091000'
        # roll_date_info.start_of_roll_period == Timestamp('2009-09-17 23:00:01')
        # roll_date_info.end_of_roll_period == Timestamp('2009-10-19 23:00:00')
        current_price_data = dict_of_futures_contract_closing_prices[contract_date_info.current_contract_str][roll_date_info.start_of_roll_period:roll_date_info.end_of_roll_period]

Which misses data from the roll period.
FYI the roll calendar looks like:

    DATE_TIME,current_contract,next_contract,carry_contract
    2009-09-17 23:00:00,20090900,20091000,20091000
    2009-10-19 23:00:00,20091000,20091100,20091100
    2009-11-18 23:00:00,20091100,20091200,20091200

And your multiple prices look like:

    DATETIME,CARRY,CARRY_CONTRACT,PRICE,PRICE_CONTRACT,FORWARD,FORWARD_CONTRACT
    2009-09-16 23:00:00,312.7,20091000,312.7,20090900,312.7,20091000
    2009-09-17 23:00:00,312.5,20091100,313.8,20091000,312.5,20091100
    2009-09-18 23:00:00,312.1,20091100,313.5,20091000,312.1,20091100


