### PR TITLE
Update fileutils.py

### DIFF
--- a/syscore/fileutils.py
+++ b/syscore/fileutils.py
@@ -47,6 +47,9 @@ def get_filename_for_package(pathname:str, filename=None):
     Relative filenames do not
     """
     markedup_pathname = add_ampersand_to_pathname(pathname)
+    if os.path.isfile(pathname) == True and filename == None:
+        #Check if pathname is a file
+        filename = pathname
     if filename is None:
         # filename will be at the end of the pathname
         path_as_list = markedup_pathname.rsplit("&")


### PR DESCRIPTION
Getting a file not found error while defining config with a absolute filepath on windows. 

>my_config = Config(r'C:\Users\User\pysystemtrade\private\this_system_name\config.yaml')
>FileNotFoundError: [Errno 2] No such file or directory: '\\Users\\User\\pysystemtrade\\private\\this_system_name\\config.yaml'

Defining filename variable as pathname, if the provided pathname is a file and filename = None, circumvents this error.