### PR TITLE
Type fixes 210625

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -4412,9 +4412,6 @@ Diagnostics:
 |:-------------------------:|:---------:|:---------------:|:----:|:--------------------------------------------------------------:|
 | `accounts.list_of_trading_rules`| Standard | | D | All trading rules across instruments|
 | `accounts.get_instrument_scaling_factor`| Standard | `instrument_code` | D | IDM * instrument weight|
-| `accounts.get_forecast_scaling_factor`| Standard | `instrument_code`, `rule_variation_name` | D | FDM * forecast weight|
-| `accounts.get_instrument_forecast_scaling_factor`| Standard | `instrument_code`, `rule_variation_name` | D | IDM * instrument weight * FDM * forecast weight|
-| `accounts.get_capital_in_rule`| Standard | `rule_variation_name` | D | Sum of `get_instrument_forecast_scaling_factor` for a given trading rule|
 | `accounts.get_buffered_position`| Standard | `instrument_code` | D | Buffered position at portfolio level|
 | `accounts.get_buffered_position_with_multiplier`| Standard | `instrument_code` | D | Buffered position at portfolio level, including capital multiplier|
 | `accounts.subsystem_turnover`| Standard | `instrument_code` | D | Annualised turnover of subsystem|

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -3610,8 +3610,9 @@ Weighting for trading rules p&l is a *little* complicated.
 
 *`pandl_for_instrument_forecast`:* If I want the p&l of a single trading rule
 for one instrument in isolation, then I use `pandl_for_instrument_forecast`.
+
 *`pandl_for_trading_rule_unweighted`*: If I aggregate these across instruments
-then I get `pandl_for_trading_rule_unweighted`. The individiual unweighted
+then I get `pandl_for_trading_rule_unweighted`. The individual unweighted
 curves are instrument p&l for each instrument and forecast.
 
 *`pandl_for_instrument_forecast_weighted`:* The weighted p&l of a single


### PR DESCRIPTION
typo fixes in backtesting.md
- A few typo and format fixes
- Remove some no longer exist method descriptions.