### PR TITLE
Handle missing bid/ask data

### DIFF
--- a/sysexecution/stack_handler/additional_sampling.py
+++ b/sysexecution/stack_handler/additional_sampling.py
@@ -53,7 +53,8 @@ class stackHandlerAdditionalSampling(stackHandlerCore):
 
     def refresh_sampling_without_checks(self, contract: futuresContract):
         average_spread = self.get_average_spread(contract)
-        self.add_spread_data_to_db(contract, average_spread)
+        if average_spread is not missing_data:
+            self.add_spread_data_to_db(contract, average_spread)
 
     def get_average_spread(self, contract:futuresContract) -> float:
         data_broker = self.data_broker


### PR DESCRIPTION
get_average_spread can return missing_data, so it should be handled without crashing the stack handler (at least I assume that crashing is not the desired behavior)