### PR TITLE
IB gateway Read only mode + minor fixes and documentation additions

### DIFF
--- a/docs/IB.md
+++ b/docs/IB.md
@@ -80,14 +80,14 @@ You will also need to configure the Gateway:
 
 - Socket port: Should be 4001. If you use a different port you'll need to change your connection calls [here](#making-a-connection) and [here](#creating-and-closing-connection-objects)
 - White list for trusted IP addresses: Should include 127.0.0.1. If you are going to be running the Gateway on one machine, and accessing it via another, then you need to add the IP address of your other machines here.
-- If you are going to be trading, then 'Read only API' should be turned off
+- If you are going to be trading, then 'Read only API' should be turned off. You can however use the Gateway in Read only mode for fetching (historical) market data and simulating creating orders (see [here](#creating-and-closing-connection-objects) how to configure that)
 - You may also need to change precautions and preset options
 
 ## Making a connection
 
 ```
 from sysbrokers.IB.ib_connection import connectionIB
-conn = connectionIB( 999, ib_ipaddress = "127.0.0.1", ib_port=4001, account="U999999") # the first compulsory value is the client_id; the keyword args are the default values and can be omitted
+conn = connectionIB( 999, ib_ipaddress = "127.0.0.1", ib_port=4001, ib_readonly=false, account="U999999") # the first compulsory value is the client_id; the keyword args are the default values and can be omitted
 conn
 # In production the client id is assigned from a database to avoid conflicts
 Out[13]: IB broker connection{'ipaddress': '127.0.0.1', 'port': 4001, 'client': 999} 
@@ -252,7 +252,7 @@ You wouldn't normally open a separate IB connection in pysystemtrade since they 
 
 ```
 from sysbrokers.IB.ib_connection import connectionIB
-conn = connectionIB(1, ib_ipaddress = "127.0.0.1", ib_port=4001, account="U123456")
+conn = connectionIB(1, ib_ipaddress = "127.0.0.1", ib_port=4001, ib_readonly=false, account="U123456")
 ```
 
 Portid should match that in the Gateway configuration. Client ids (eg 1) must not be duplicated by an already connected python process (even if it's hung... normally in production the client id is assigned from a database to avoid conflicts). The IP address shown means 'this machine'; only change this if you are planning to run the Gateway on a different network machine.
@@ -267,8 +267,12 @@ You should first create a file 'private_config.yaml' in the private directory of
 ```
 ib_ipaddress: 192.168.0.10
 ib_port: 4001
+ib_readonly: False
 broker_account: U123456
 ```
+
+For preliminary testing you can allow the framework to handle Read only mode by setting 'ib_readonly: True'. This will make it possible to fetch historical market data with 'seed_price_data_from_IB.py' even if Read only mode is enabled in the Gateway. Market orders created by stack handler will be delivered to IB API but will be canceled and bounced back. In current implementation the stack handler will keep recreating the orders indefinitely though. 
+
 
 ```
 conn = connectionIB(config)

--- a/docs/production.md
+++ b/docs/production.md
@@ -732,6 +732,22 @@ email_server: 'smtp.anemailadress.com'
 email_to: "someotherbloke@anothermail.com"
 ```
 
+Pysystemtrade will automatically try to negotiate TLS encryption when connecting to SMTP server and will resort to unencrypted communication only as a last resort.
+
+To use Google SMTP server without trusting the config file with your plain text password, you can create an 'App password' specifically for pysystemtrade:
+- Go to [Manage my Google account](https://myaccount.google.com/security) and its 'Signing in to Google' subsection
+- Ensure that '2-step verification' is On
+- In 'App passwords' section generate a new one: Select app: Mail. Select device: Other, and name it 'pysystemtrade'. Click 'Generate' and copy the 16-character password (such as 'abcd efgh ijkl mnop').
+
+For sending notifications via gmail to yourself, edit the config file as below:
+```
+email_address: "youraddress@gmail.com"
+email_pwd: "abcdefghijklmnop"
+email_server: 'smtp.gmail.com'
+email_to: "youraddress@gmail.com"
+```
+
+
 Reports are run automatically every day by the [run reports](#run-all-reports) process, but you can also run ad-hoc reports in the [interactive diagnostics](#reports) tool. Ad hoc reports can be emailed or displayed on screen.
 
 Full details of reports are given [here](#reports-1).

--- a/docs/production.md
+++ b/docs/production.md
@@ -506,7 +506,7 @@ You are probably going to want to link your system to a broker, to do one or mor
 
 ... although one or more of these can also be done manually.
 
-You should now read [connecting pysystemtrade to interactive brokers](/docs/IB.md). The fields `broker_account`,`ib_ipaddress`, `ib_port` and `ib_idoffset` should be set in the [private config file](/private/private_config.yaml).
+You should now read [connecting pysystemtrade to interactive brokers](/docs/IB.md). The fields `broker_account`,`ib_ipaddress`, `ib_port`, `ib_readonly` and `ib_idoffset` should be set in the [private config file](/private/private_config.yaml).
 
 
 ## Other data sources
@@ -2619,6 +2619,7 @@ The following are configuration options that are in defaults.yaml and can be ove
 [Broker](#linking-to-a-broker)
 - `ib_ipaddress`: 127.0.0.1
 - `ib_port`: 4001
+- `ib_readonly`: False
 - `ib_idoffset`: 100
 
 [Database](#data-storage)

--- a/sysbrokers/IB/client/ib_client_id.py
+++ b/sysbrokers/IB/client/ib_client_id.py
@@ -16,7 +16,7 @@ class ibBrokerClientIdData(brokerClientIdData):
         log=logtoscreen("brokerClientIdTracker"),
     ):
         if idoffset is arg_not_supplied:
-            _notused_ipaddress, _notused_port, idoffset = ib_defaults()
+            _notused_ipaddress, _notused_port, _notused_readonly, idoffset = ib_defaults()
 
         super().__init__(log=log, idoffset=idoffset)
 

--- a/sysbrokers/IB/ib_connection.py
+++ b/sysbrokers/IB/ib_connection.py
@@ -28,6 +28,7 @@ class connectionIB(object):
         ib_ipaddress: str=arg_not_supplied,
         ib_port: int=arg_not_supplied,
         account: str = arg_not_supplied,
+        ib_readonly: str = arg_not_supplied,
         log=logtoscreen("connectionIB")
     ):
         """
@@ -35,12 +36,12 @@ class connectionIB(object):
         :param ipaddress: IP address of machine running IB Gateway or TWS. If not passed then will get from private config file, or defaults
         :param port: Port listened to by IB Gateway or TWS
         :param log: logging object
-        :param mongo_db: mongoDB connection
+        :param ib_readonly: Connection can be made to gateway/TWS that is in read-only mode
         """
 
         # resolve defaults
 
-        ipaddress, port, __ = ib_defaults(ib_ipaddress=ib_ipaddress, ib_port=ib_port)
+        ipaddress, port, readonly, __ = ib_defaults(ib_ipaddress=ib_ipaddress, ib_port=ib_port, readonly=ib_readonly)
 
         # The client id is pulled from a mongo database
         # If for example you want to use a different database you could do something like:
@@ -52,7 +53,7 @@ class connectionIB(object):
         # If you copy for another broker include this line
         log.label(broker="IB", clientid=client_id)
         self._ib_connection_config = dict(
-            ipaddress=ipaddress, port=port, client=client_id)
+            ipaddress=ipaddress, port=port, client=client_id, readonly=readonly)
 
         ib = IB()
 
@@ -63,10 +64,10 @@ class connectionIB(object):
         ## that may still return missing data...
         if account is missing_data:
             self.log.error("Broker account ID not found in private config - may cause issues")
-            ib.connect(ipaddress, port, clientId=client_id)
+            ib.connect(ipaddress, port, clientId=client_id, readonly=readonly)
         else:
-            ## conncect using account
-            ib.connect(ipaddress, port, clientId=client_id, account=account)
+            ## connect using account
+            ib.connect(ipaddress, port, clientId=client_id, readonly=readonly, account=account)
 
         # Sometimes takes a few seconds to resolve... only have to do this once per process so no biggie
         time.sleep(5)
@@ -74,6 +75,7 @@ class connectionIB(object):
         self._ib = ib
         self._log = log
         self._account = account
+        self._readonly = readonly
 
     @property
     def ib(self):

--- a/sysbrokers/IB/ib_connection_defaults.py
+++ b/sysbrokers/IB/ib_connection_defaults.py
@@ -1,14 +1,14 @@
 from sysdata.config.production_config import get_production_config
 from syscore.objects import arg_not_supplied
 
-LIST_OF_IB_PARAMS = ["ib_ipaddress", "ib_port", "ib_idoffset"]
+LIST_OF_IB_PARAMS = ["ib_ipaddress", "ib_port", "ib_idoffset", "ib_readonly"]
 
 
 def ib_defaults(**kwargs):
     """
     Returns ib configuration with following precedence
-    1- if passed in arguments: ipaddress, port, idoffset - use that
-    2- if defined in private_config file, use that. ib_ipaddress, ib_port, ib_idoffset
+    1- if passed in arguments: ipaddress, port, idoffset, readonly - use that
+    2- if defined in private_config file, use that. ib_ipaddress, ib_port, ib_idoffset, ib_readonly
     3 - if defined in system defaults file, use that
 
     :return: mongo db, hostname, port
@@ -33,5 +33,6 @@ def ib_defaults(**kwargs):
     ipaddress = output_dict['ib_ipaddress']
     port = output_dict['ib_port']
     idoffset = output_dict['ib_idoffset']
+    readonly = output_dict['ib_readonly']
 
-    return ipaddress, port, idoffset
+    return ipaddress, port, readonly, idoffset

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -32,6 +32,7 @@ echo_directory: 'data.echos'
 ib_ipaddress: 127.0.0.1
 ib_port: 4001
 ib_idoffset: 100
+ib_readonly: False
 #
 # Mongo DB
 mongo_host: 127.0.0.1

--- a/sysdata/data_blob.py
+++ b/sysdata/data_blob.py
@@ -309,7 +309,7 @@ class dataBlob(object):
 
     @property
     def log_name(self) -> str:
-        log_name = getattr(self, "_logname", "")
+        log_name = getattr(self, "_log_name", "")
         return log_name
 
 

--- a/sysinit/futures/barchart_futures_contract_prices.py
+++ b/sysinit/futures/barchart_futures_contract_prices.py
@@ -12,13 +12,13 @@ def strip_file_names(pathname):
     for filename in file_names:
         identifier = filename.split("_")[0]
         yearcode = int(identifier[len(identifier)-2:])
-        monthcode = identifier[len(identifier)-3]
+        monthcode = identifier[len(identifier)-3].upper()
         if yearcode>50:
             year = 1900+yearcode
         else:
             year = 2000+yearcode
         month = month_from_contract_letter(monthcode)
-        marketcode = identifier[:len(identifier)-3]
+        marketcode = identifier[:len(identifier)-3].upper()
         instrument = market_map[marketcode]
 
         datecode = str(year)+'{0:02d}'.format(month)
@@ -39,17 +39,18 @@ market_map = dict( AE="AEX", A6="AUD", HR="BOBL", II = "BTP",MX = "CAC", GG="BUN
                    PA="PALLAD",                   HF="SHATZ", PL="PLAT",ZS = "SOYBEAN",
                    ES="SP500",ZT = "US2",   ZF = "US5",ZN = "US10",
                    ZB="US20",VI = "VIX",ZW="WHEAT",
-                   DV="V2X",
-                    UD = "US30"
+                   DV="V2X", UD = "US30", FX = "EUROSTX", 
+                   GR = "GOLD_micro", NM = "NASDAQ_micro", QM = "CRUDE_W_mini", QG = "GAS_US_mini", ET ="SP500_micro"
                    )
 
 
-barchart_csv_config = ConfigCsvFuturesPrices(input_date_index_name="Date Time",
-                                input_skiprows=1, input_skipfooter=1,
+barchart_csv_config = ConfigCsvFuturesPrices(input_date_index_name="Time",
+                                input_skiprows=0, input_skipfooter=1,
+                                input_date_format="%m/%d/%Y",
                                 input_column_mapping=dict(OPEN='Open',
                                                           HIGH='High',
                                                           LOW='Low',
-                                                          FINAL='Close',
+                                                          FINAL='Last',
                                                           VOLUME='Volume'
                                                           ))
 

--- a/sysinit/futures/build_roll_calendars.py
+++ b/sysinit/futures/build_roll_calendars.py
@@ -198,6 +198,10 @@ def adjust_to_price_series(approx_calendar: pd.DataFrame,
         adjusted_roll_calendar_as_list.append(adjusted_row)
         _print_adjustment_message(local_row_data, adjusted_row)
 
+    if len(adjusted_roll_calendar_as_list) == 0:
+        raise Exception(
+            "Error! Empty roll calendar after adjustment! Most likely corrupted roll calendar or maybe using old roll calendar .csv files with new price data?")
+
     new_calendar = adjusted_roll_calendar_as_list.to_pd_df()
 
     return new_calendar
@@ -287,10 +291,9 @@ def _get_set_of_prices(local_row_data: localRowData,
 
     try:
         current_prices = dict_of_futures_contract_prices[current_contract]
+        next_prices = dict_of_futures_contract_prices[next_contract]
     except KeyError:
         return _bad_row
-
-    next_prices = dict_of_futures_contract_prices[next_contract]
 
     carry_contract, carry_prices, curr_carry_contract, curr_carry_prices = _get_carry_contract_and_prices(local_row_data,
                                                                                  dict_of_futures_contract_prices)
@@ -311,10 +314,16 @@ def _get_carry_contract_and_prices(local_row_data, dict_of_futures_contract_pric
         curr_carry_prices = _no_carry_prices
         curr_carry_contract = _no_carry_prices
     else:
-        carry_contract = str(next_approx_row.carry_contract)
-        carry_prices = dict_of_futures_contract_prices[carry_contract]
-        curr_carry_contract = str(curr_approx_row.carry_contract)
-        curr_carry_prices = dict_of_futures_contract_prices[curr_carry_contract]
+        try:
+            carry_contract = str(next_approx_row.carry_contract)
+            carry_prices = dict_of_futures_contract_prices[carry_contract]
+        except KeyError:
+            carry_prices = _no_carry_prices
+        try:
+            curr_carry_contract = str(curr_approx_row.carry_contract)
+            curr_carry_prices = dict_of_futures_contract_prices[curr_carry_contract]
+        except KeyError:
+            curr_carry_prices = _no_carry_prices
 
     return carry_contract, carry_prices, curr_carry_contract, curr_carry_prices
 
@@ -377,7 +386,8 @@ def _required_paired_prices(set_of_prices: setOfPrices)\
                             -> pd.DataFrame:
 
     no_carry_exists = set_of_prices.carry_prices is _no_carry_prices
-    if no_carry_exists:
+    no_curr_carry_exists = set_of_prices.curr_carry_prices is _no_carry_prices
+    if no_carry_exists or no_curr_carry_exists:
         paired_prices = pd.concat([set_of_prices.current_prices,
                                    set_of_prices.next_prices], axis=1)
     else:

--- a/sysinit/futures/spotfx_from_csvAndInvestingDotCom_to_arctic.py
+++ b/sysinit/futures/spotfx_from_csvAndInvestingDotCom_to_arctic.py
@@ -20,7 +20,8 @@ def spotfx_from_csv_and_investing_dot_com(datapath, ADD_TO_ARCTIC = True, ADD_TO
     # You can adapt this for different providers by changing these parameters
     if ADD_EXTRA_DATA:
         investingDotCom_csv_fx_prices = csvFxPricesData(
-            datapath=datapath)
+            datapath = datapath,
+            config = investing_dot_com_config)
     if ADD_TO_ARCTIC:
         arctic_fx_prices = arcticFxPricesData()
     my_csv_fx_prices = csvFxPricesData()

--- a/sysproduction/backup_arctic_to_csv.py
+++ b/sysproduction/backup_arctic_to_csv.py
@@ -99,7 +99,7 @@ def get_data_and_create_csv_directories(logname):
         dir_name = "%s/%s/" % (csv_dump_dir, path)
         class_paths[class_name] = dir_name
         if not os.path.exists(dir_name):
-            os.mkdir(dir_name)
+            os.makedirs(dir_name)
 
     data = dataBlob(
         csv_data_paths=class_paths, keep_original_prefix=True, log_name=logname

--- a/sysproduction/data/backtest.py
+++ b/sysproduction/data/backtest.py
@@ -192,7 +192,7 @@ def store_backtest_state(data, system, strategy_name="default_strategy"):
 def ensure_backtest_directory_exists(strategy_name):
     full_directory = get_backtest_directory_for_strategy(strategy_name)
     try:
-        os.mkdir(full_directory)
+        os.makedirs(full_directory)
     except FileExistsError:
         pass
 

--- a/sysproduction/data/strategies.py
+++ b/sysproduction/data/strategies.py
@@ -1,5 +1,5 @@
 from sysdata.data_blob import dataBlob
-from syscore.objects import arg_not_supplied
+from syscore.objects import missing_data, arg_not_supplied
 from syscore.interactive import print_menu_of_values_and_get_response
 from sysproduction.data.positions import diagPositions, dataOptimalPositions
 
@@ -17,12 +17,16 @@ class diagStrategiesConfig(productionDataLayerGeneric):
 
     def get_strategy_config_dict_for_strategy(self, strategy_name: str) -> dict:
         strategy_dict = self.get_all_strategy_dict()
+        if strategy_dict is missing_data:
+                raise Exception("strategy_list not defined in defaults.yaml or private yaml config!")
         this_strategy_dict = strategy_dict[strategy_name]
 
         return this_strategy_dict
 
     def get_list_of_strategies(self) -> list:
         strategy_dict = self.get_all_strategy_dict()
+        if strategy_dict is missing_data:
+                raise Exception("strategy_list not defined in defaults.yaml or private yaml config!")
         list_of_strategies = list(strategy_dict.keys())
 
         return list_of_strategies

--- a/sysproduction/strategy_code/strategy_allocation.py
+++ b/sysproduction/strategy_code/strategy_allocation.py
@@ -71,7 +71,7 @@ def strategy_weights_if_none_passed(data: dataBlob) -> dict:
     list_of_strategies = get_list_of_strategies_from_config(data)
     count_of_strateges = len(list_of_strategies)
     weight = 100.0/count_of_strateges
-    data.log("No configuration for strategy weight defined in private config; equally weighting across %s each gets %f percent" %
+    data.log.warn("No configuration for strategy weight defined in private config; equally weighting across %s each gets %f percent" %
              (str(list_of_strategies), weight))
     output_dict = dict([(strat_name, weight) for strat_name in list_of_strategies])
 

--- a/sysproduction/update_strategy_capital.py
+++ b/sysproduction/update_strategy_capital.py
@@ -44,7 +44,7 @@ class updateStrategyCapital(object):
         except Exception as e:
             # Problem, will send email
             self.data.log.critical(
-                "Error %s whilst allocating strategy capital" %
+                "Error [%s] whilst allocating strategy capital" %
                 e)
 
         return None


### PR DESCRIPTION
- feed_price_data_from_IB.py wouldn't work with Read only mode (!) so I made a configuration setting which allows this. 
- Documentation on how to use Gmail for e-mail notifications without using your plain text (master) password
- Few minor fixes that make running the system a bit more robust out-of-the-box (or at least give more meaningful error messages instead of crashing). 
