### PR TITLE
Correlation estimates memory and performance fix

### DIFF
--- a/syscore/pdutils.py
+++ b/syscore/pdutils.py
@@ -556,3 +556,12 @@ def get_row_of_df_aligned_to_weights_as_dict(df: pd.DataFrame,
             raise Exception("Date %s not found in portfolio weights" % str(relevant_date))
 
     return data_at_date.to_dict()
+
+
+def get_max_index_before_datetime(index, date_point):
+    matching_index_size = index[index < date_point].size
+
+    if matching_index_size == 0:
+        return None
+    else:
+        return matching_index_size - 1

--- a/sysquant/estimators/exponential_correlation.py
+++ b/sysquant/estimators/exponential_correlation.py
@@ -101,7 +101,6 @@ class exponentialCorrelationResults(object):
         columns = data_for_correlation.columns
         self._columns = columns
 
-
         raw_correlations = data_for_correlation.ewm(
             span=ew_lookback,
             min_periods=min_periods, ignore_na=True).corr(
@@ -114,26 +113,17 @@ class exponentialCorrelationResults(object):
         return self._raw_correlations
 
     def last_valid_cor_matrix_for_date(self, date_point: datetime.datetime) -> correlationEstimate:
-        first_index, last_index = self._range_of_indices_for_date(date_point)
         raw_correlations = self.raw_correlations
+        corr_matrix_values = \
+                raw_correlations[raw_correlations.index.get_level_values(0) < date_point].\
+                tail(self.size_of_matrix).values
 
-        # slicing is weird
-        corr_matrix_values = raw_correlations[first_index:last_index].values
-        columns = self.columns
-
-        return correlationEstimate(values=corr_matrix_values, columns=columns)
-
-    def _range_of_indices_for_date(self, date_point: datetime.datetime) -> (int, int):
-        index = self.raw_correlations.index
-        last_index = index[index.get_level_values(0) < date_point].size
-        first_index = last_index - self.size_of_matrix
-
-        return first_index, last_index
+        return correlationEstimate(values=corr_matrix_values, columns=self.columns)
 
     @property
     def size_of_matrix(self) -> int:
         return len(self.columns)
 
     @property
-    def columns(self)-> list:
+    def columns(self) -> list:
         return self._columns

--- a/sysquant/estimators/exponential_correlation.py
+++ b/sysquant/estimators/exponential_correlation.py
@@ -118,15 +118,15 @@ class exponentialCorrelationResults(object):
         raw_correlations = self.raw_correlations
 
         # slicing is weird
-        corr_matrix_values = raw_correlations[(first_index+1):(last_index+1)].values
+        corr_matrix_values = raw_correlations[first_index:last_index].values
         columns = self.columns
 
         return correlationEstimate(values=corr_matrix_values, columns=columns)
 
     def _range_of_indices_for_date(self, date_point: datetime.datetime) -> (int, int):
-        last_index = self._index_of_datetime_in_data(date_point)
-        size_of_matrix = self.size_of_matrix
-        first_index = last_index - size_of_matrix
+        index = self.raw_correlations.index
+        last_index = index[index.get_level_values(0) < date_point].size
+        first_index = last_index - self.size_of_matrix
 
         return first_index, last_index
 
@@ -137,31 +137,3 @@ class exponentialCorrelationResults(object):
     @property
     def columns(self)-> list:
         return self._columns
-
-    def _index_of_datetime_in_data(self, date_point: datetime.datetime) -> int:
-        ts_index = self.index
-        xpoint = [index_idx for index_idx, index_date in
-                  enumerate(ts_index) if index_date<date_point]
-        if len(xpoint)==0:
-            return 0
-
-        last_index = xpoint[-1]
-
-        return last_index
-
-    @property
-    def index(self) -> list:
-        # don't recalculate as slow
-        ts_index = getattr(self, "_ts_index", None)
-        if ts_index is None:
-            ts_index = self._ts_index = \
-                self._calculate_index_of_timestampes_in_raw_correlations()
-
-        return ts_index
-
-    def _calculate_index_of_timestampes_in_raw_correlations(self) -> list:
-        raw_correlations = self.raw_correlations
-        ts_index = [x[0] for x in raw_correlations.index]
-
-        return ts_index
-

--- a/sysquant/estimators/mean_estimator.py
+++ b/sysquant/estimators/mean_estimator.py
@@ -2,7 +2,7 @@ import pandas as pd
 import  numpy as np
 
 from syscore.algos import apply_with_min_periods
-from syscore.pdutils import how_many_times_a_year_is_pd_frequency
+from syscore.pdutils import how_many_times_a_year_is_pd_frequency, get_max_index_before_datetime
 
 from sysquant.fitting_dates import fitDates
 from sysquant.estimators.generic_estimator import genericEstimator, exponentialEstimator, Estimate
@@ -54,15 +54,11 @@ class exponentialMeans(exponentialEstimator):
 
 
     def get_estimate_for_fitperiod_with_data(self, fit_period: fitDates) -> meanEstimates:
+        exponential_mean_df = self.calculations
 
-        exponential_mean_df= self.calculations
-        ts_index = exponential_mean_df.index
-        xpoint = [index_idx for index_idx, index_date in
-                  enumerate(ts_index) if index_date<fit_period.fit_end]
-        if len(xpoint)==0:
-            return empty_mean(self.data)
-
-        last_index = xpoint[-1]
+        last_index = get_max_index_before_datetime(exponential_mean_df.index, fit_period.fit_end)
+        if last_index is None:
+            return empty_stdev(self.data)
 
         mean = meanEstimates(exponential_mean_df.iloc[last_index])
         mean = annualise_mean_estimate(mean, frequency=self.frequency)

--- a/sysquant/estimators/stdev_estimator.py
+++ b/sysquant/estimators/stdev_estimator.py
@@ -2,7 +2,7 @@ import pandas as pd
 import  numpy as np
 
 from syscore.algos import apply_with_min_periods
-from syscore.pdutils import how_many_times_a_year_is_pd_frequency
+from syscore.pdutils import how_many_times_a_year_is_pd_frequency, get_max_index_before_datetime
 
 from sysquant.fitting_dates import fitDates
 from sysquant.estimators.generic_estimator import genericEstimator, exponentialEstimator, Estimate
@@ -48,16 +48,13 @@ class exponentialStdev(exponentialEstimator):
 
         return stdev_calculations
 
+
     def get_estimate_for_fitperiod_with_data(self, fit_period: fitDates) -> stdevEstimates:
+        exponential_std_deviation = self.calculations
 
-        exponential_std_deviation= self.calculations
-        ts_index = exponential_std_deviation.index
-        xpoint = [index_idx for index_idx, index_date in
-                  enumerate(ts_index) if index_date<fit_period.fit_end]
-        if len(xpoint)==0:
+        last_index = get_max_index_before_datetime(exponential_std_deviation.index, fit_period.fit_end)
+        if last_index is None:
             return empty_stdev(self.data)
-
-        last_index = xpoint[-1]
 
         stdev = stdevEstimates(exponential_std_deviation.iloc[last_index])
         stdev = annualise_stdev_estimate(stdev, frequency=self.frequency)

--- a/sysquant/optimisation/generic_optimiser.py
+++ b/sysquant/optimisation/generic_optimiser.py
@@ -14,14 +14,10 @@ class genericOptimiser(object):
 
         net_returns = returns_pre_processor.get_net_returns(asset_name)
 
-        optimiser_over_time = optimiseWeightsOverTime(net_returns, log = log,
-                                          **weighting_params)
-
         self._net_returns = net_returns
         self._weighting_params = weighting_params
         self._log = log
         self._returns_processor = returns_pre_processor
-        self._optimiser_over_time = optimiser_over_time
         self._asset_name = asset_name
 
 
@@ -50,12 +46,7 @@ class genericOptimiser(object):
     def weighting_params(self) -> dict:
         return self._weighting_params
 
-    @property
-    def optimiser_over_time(self) -> optimiseWeightsOverTime:
-        return self._optimiser_over_time
-
     def weights(self) -> pd.DataFrame:
-
         raw_weights = self.raw_weights()
         weights = self.weights_post_processing(raw_weights)
 
@@ -63,10 +54,9 @@ class genericOptimiser(object):
         return weights
 
     def raw_weights(self) -> pd.DataFrame:
-        optimiser = self.optimiser_over_time
-        weights = optimiser.weights()
+        optimiser = optimiseWeightsOverTime(self.net_returns, log=self.log, **self.weighting_params)
 
-        return weights
+        return optimiser.weights()
 
     def weights_post_processing(self, weights: pd.DataFrame) -> pd.DataFrame:
         # apply cost weights


### PR DESCRIPTION
This PR improves memory consumption and performance when estimating exponential correlation. The problem was unnecessary caching of the `optimiseWeightsOverTime` and `ts_index`, which prevented garbage collection. I've also managed to vectorize picking the correct subset of correlations.

On my machine, this code is a few times faster and consumes tens of GB of RAM less.