### PR TITLE
Speed optimizations

### DIFF
--- a/sysdata/arctic/arctic_connection.py
+++ b/sysdata/arctic/arctic_connection.py
@@ -49,6 +49,9 @@ class arcticData(object):
     def get_keynames(self) -> list:
         return self.library.list_symbols()
 
+    def has_keyname(self, keyname) -> bool:
+        return self.library.has_symbol(keyname)
+
     def delete(self, ident: str):
         self.library.delete(ident)
 

--- a/sysdata/arctic/arctic_futures_per_contract_prices.py
+++ b/sysdata/arctic/arctic_futures_per_contract_prices.py
@@ -89,6 +89,11 @@ class arcticFuturesContractPriceData(futuresContractPriceData):
 
         return list_of_contracts
 
+
+    def has_data_for_contract(self, contract_object: futuresContract) ->bool:
+        return self.arctic_connection.has_keyname(from_contract_to_key(contract_object))
+
+
     def _get_contract_tuples_with_price_data(self) -> list:
         """
 

--- a/sysdata/csv/csv_futures_contract_prices.py
+++ b/sysdata/csv/csv_futures_contract_prices.py
@@ -181,6 +181,10 @@ class csvFuturesContractPriceData(futuresContractPriceData):
 
         return list_of_contract_tuples
 
+    def has_data_for_contract(self, contract_object: futuresContract) ->bool:
+        if self._keyname_given_contract_object(contract_object) in self._all_keynames_in_library():
+            return True
+
     def get_contracts_with_price_data(self) ->listOfFuturesContracts:
         """
 

--- a/sysdata/futures/futures_per_contract_prices.py
+++ b/sysdata/futures/futures_per_contract_prices.py
@@ -170,10 +170,8 @@ class futuresContractPriceData(baseData):
         :return: None
         """
 
-        if self.has_data_for_contract(futures_contract_object):
-            if ignore_duplication:
-                pass
-            else:
+        if ignore_duplication == False:
+            if self.has_data_for_contract(futures_contract_object):
                 log = futures_contract_object.log(self.log)
                 log.warn(
                     "There is already existing data for %s" % futures_contract_object.key)


### PR DESCRIPTION
When processing Arctic data or CSV files and checking if contract has price data, instead of fetching all contracts we just check if the relevant key(Arctic) or file(.CSV) exists. When (tens of) thousands contracts exists in database this helps speed up processing tremendously.

Also when writing new price data and overwriting is allowed, we do not check in vain if old price data exists