### PR TITLE
Update roll_calendars.py

### DIFF
--- a/sysobjects/roll_calendars.py
+++ b/sysobjects/roll_calendars.py
@@ -111,9 +111,9 @@ class rollCalendar(pd.DataFrame):
 def _check_row_of_row_calendar(calendar_row: pd.Series,
                                dict_of_futures_contract_prices: dictFuturesContractFinalPrices) ->bool:
 
-    current_contract = calendar_row.current_contract
-    next_contract = calendar_row.next_contract
-    carry_contract = calendar_row.carry_contract
+    current_contract = str(calendar_row.current_contract)
+    next_contract = str(calendar_row.next_contract)
+    carry_contract = str(calendar_row.carry_contract)
     roll_date = calendar_row.name
 
     try:


### PR DESCRIPTION
contract references as strings (as opposed to integers) in _check_row_of_row_calendar, as expected as keys by dict_of_futures_contract_prices.
---
I'm getting errors running `sysinit.futures.rollcalendars_from_arcticprices_to_csv.check_saved_roll_calendar` saying that *all* of the contracts are missing even though (a) they are all there with prices on the relevant dates and (b) the multiple prices and adjusted prices generated are absolutely fine.

Tracing the error back, I believe it is because `sysobjects.roll_calendars._check_row_of_row_calendar` gets the dates for the relevant contracts, but they are coming back as integers rather than as strings, as expected as dictionary keys a few lines later in:

`current_prices = dict_of_futures_contract_prices[current_contract]`

(you can see it expects strings because `dict_of_futures_contract_prices.keys()` is a list of strings.)  I think the fix is therefore easy: simply extract them from `calendar_row` as strings.