### PR TITLE
Speed up mongo calls

### DIFF
--- a/sysdata/mongodb/mongo_generic.py
+++ b/sysdata/mongodb/mongo_generic.py
@@ -57,11 +57,14 @@ class mongoDataWithSingleKey(object):
         return self._mongo.collection
 
     def get_list_of_keys(self)->list:
-        cursor = self.collection.find()
-        key_name = self.key_name
-        key_list = [db_entry[key_name] for db_entry in cursor]
+        return self.collection.distinct(self.key_name)
 
-        return key_list
+    def get_max_of_keys(self)->int:
+        doc = self.collection.find_one(sort=[(self.key_name, -1)])
+        if self.key_name in doc:
+            return doc[self.key_name]
+        else:
+            return 0
 
     def get_list_of_values_for_dict_key(self, dict_key):
         key_list = self.get_list_of_keys()

--- a/sysdata/mongodb/mongo_generic.py
+++ b/sysdata/mongodb/mongo_generic.py
@@ -67,11 +67,7 @@ class mongoDataWithSingleKey(object):
             return 0
 
     def get_list_of_values_for_dict_key(self, dict_key):
-        key_list = self.get_list_of_keys()
-        list_of_results = [self.get_result_dict_for_key(key) for key in key_list]
-        list_of_values = [item_dict.get(dict_key, None) for item_dict in list_of_results]
-
-        return list_of_values
+        return [row[dict_key] for row in self.collection.find({self.key_name: {"$exists": True}}, {dict_key: 1})]
 
     def get_result_dict_for_key(self, key) ->dict:
         key_name = self.key_name

--- a/sysdata/mongodb/mongo_log.py
+++ b/sysdata/mongodb/mongo_log.py
@@ -55,14 +55,12 @@ class logToMongod(logToDb):
 
         :return: int or None
         """
-        all_log_ids = self._get_all_log_ids()
-        if len(all_log_ids)==0:
+        current_max = self.mongo_data.get_max_of_keys()
+        if current_max == None:
             return 0
 
-        return max(all_log_ids)
+        return current_max
 
-    def _get_all_log_ids(self) -> list:
-        return self.mongo_data.get_list_of_keys()
 
     def _reserve_log_id(self, next_id: int) -> bool:
         try:


### PR DESCRIPTION
When getting the next log ID key from the mongo db, all existing keys were being returned, iterated over and then `max`ed.

This patch makes the database do the work. Significantly reduces the time when entering the various scripts and interactive consoles, as it does not have to spend so long to get the next log ID.