### PR TITLE
Rsync improvements

### DIFF
--- a/syscore/fileutils.py
+++ b/syscore/fileutils.py
@@ -75,6 +75,9 @@ def add_ampersand_to_pathname(pathname: str) -> str:
 
 def get_resolved_pathname(pathname):
     # Turn /,\ into . so system independent
+    if "@" in pathname:
+        # This is an ssh address for rsync - don't change
+        return pathname
     pathname_replaced_with_ampersands = add_ampersand_to_pathname(pathname)
     resolved_pathname = get_resolved_ampersand_pathname(pathname_replaced_with_ampersands)
 

--- a/sysproduction/backup_mongo_data_as_dump.py
+++ b/sysproduction/backup_mongo_data_as_dump.py
@@ -38,7 +38,5 @@ def dump_mongo_data(data):
 def backup_mongo_dump(data):
     source_path = get_mongo_dump_directory()
     destination_path = get_mongo_backup_directory()
-    shutil.rmtree(destination_path)
     data.log.msg("Copy from %s to %s" % (source_path, destination_path))
-    shutil.copytree(source_path, destination_path)
-
+    os.system("rsync -av %s %s" % (source_path, destination_path))


### PR DESCRIPTION
* Use rsync for all three backup operations (was two before)
* Ignore any paths from configs that contain an `@` symbol - allowing for backup paths to be SSH addresses to backup to remove server.