### PR TITLE
make pandas quiet(er)

### DIFF
--- a/syscore/pdutils.py
+++ b/syscore/pdutils.py
@@ -475,7 +475,7 @@ def make_df_from_list_of_named_tuple(tuple_class, list_of_tuples):
 
     pdf = pd.DataFrame(dict_of_elements)
     pdf.index = pdf[elements[0]]
-    pdf = pdf.drop(elements[0], axis=1)
+    pdf = pdf.drop(labels=elements[0], axis=1)
 
     return pdf
 

--- a/sysdata/csv/csv_instrument_data.py
+++ b/sysdata/csv/csv_instrument_data.py
@@ -42,7 +42,7 @@ class csvFuturesInstrumentData(futuresInstrumentData):
 
         try:
             config_data.index = config_data.Instrument
-            config_data.drop("Instrument", 1, inplace=True)
+            config_data.drop(labels="Instrument", axis=1, inplace=True)
 
         except BaseException:
             raise Exception("Badly configured file %s" % (self._config_file))

--- a/sysdata/csv/csv_roll_parameters.py
+++ b/sysdata/csv/csv_roll_parameters.py
@@ -40,7 +40,7 @@ class csvRollParametersData(rollParametersData):
 
         try:
             config_data.index = config_data.Instrument
-            config_data.drop("Instrument", 1, inplace=True)
+            config_data.drop(labels="Instrument", axis=1, inplace=True)
 
         except BaseException:
             raise Exception("Badly configured file %s" % (self._config_file))

--- a/sysinit/futures/build_roll_calendars.py
+++ b/sysinit/futures/build_roll_calendars.py
@@ -74,7 +74,7 @@ class _listOfRollCalendarRows(list):
             self
         )
         result.index = result[INDEX_NAME]
-        result = result.drop(INDEX_NAME, axis=1)
+        result = result.drop(labels=INDEX_NAME, axis=1)
 
         return result
 
@@ -529,7 +529,7 @@ def _add_carry_calendar(
 
         # do the same with the calendar or will misalign
         first_roll_date = roll_calendar.index[0]
-        roll_calendar = roll_calendar.drop(first_roll_date)
+        roll_calendar = roll_calendar.drop(labels=first_roll_date)
 
     roll_calendar["carry_contract"] = carry_contract_dates
 

--- a/systems/accounts/pandl_calculators/pandl_using_fills.py
+++ b/systems/accounts/pandl_calculators/pandl_using_fills.py
@@ -115,7 +115,7 @@ def unique_trades_df(trade_df: pd.DataFrame) -> pd.DataFrame:
     # qty and cash_flow will be correct, price won't be
     new_price = new_df.cash_flow / new_df.qty
     new_df["price"] = new_price
-    new_df = new_df.drop("cash_flow", axis=1)
+    new_df = new_df.drop(labels="cash_flow", axis=1)
 
     return new_df
 

--- a/systems/portfolio.py
+++ b/systems/portfolio.py
@@ -612,7 +612,7 @@ class Portfolios(SystemStage):
     def _remove_zero_weighted_instruments_from_df(self, some_data_frame: pd.DataFrame) -> pd.DataFrame:
         copy_df = copy(some_data_frame)
         instruments_with_zero_weights = self.allocate_zero_instrument_weights_to_these_instruments()
-        copy_df.drop(instruments_with_zero_weights)
+        copy_df.drop(labels=instruments_with_zero_weights)
 
         return copy_df
 


### PR DESCRIPTION
Prevents the oh so helpful pandas warnings like:
```
    csv_instrument_data.py:45: FutureWarning: In a future version of pandas all arguments of DataFrame.drop except for the argument 'labels' will be keyword-only
    config_data.drop("Instrument", 1, inplace=True)
```