### PR TITLE
persistence of instrument set when moving from fixed to estimated weights

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -461,6 +461,12 @@ For estimated instrument weights you'd change this section:
 instruments: ["EDOLLAR", "US10", "EUROSTX", "V2X", "MXP", "CORN"]
 ```
 
+Note that if moving from fixed to estimated instrument weights (by changing `system.config.use_instrument_weight_estimates` to `True`), the set of instruments selected in your `system.config.instrument_weights` will be ignored; if you want to continue using this same set of instruments, you need to say so:
+
+```python
+system.config.instruments = list(system.config.instrument_weights.keys())
+```
+
 (The IDM will be re-estimated automatically)
 
 You may also need to change this section, if you have different rules for each

--- a/docs/instruments.md
+++ b/docs/instruments.md
@@ -104,6 +104,11 @@ system.get_instrument_list()
 >['US5', 'US10']
 ```
 
+The code snips above make this is a good time to point out that, if you are moving from running a fixed system (i.e. fixed instrument weights) to running an estimated system (i.e. the system sets the weights), your config needs to specify a list of `instruments` *explicitly*.  The system will not presume that the set of instruments you were using in `instrument_weights` for a fixed system will be the same set of instruments you want to use for the estimated system (it will instead use all instruments for which it has data), so you need to set this config item directly, e.g.:
+
+```python
+system.config.instruments = list(system.config.instrument_weights.keys())
+```
 
 
 ## Always excluded

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pytest>6.2
 Flask>=2.0.1
 Werkzeug>=2.0.1
 cvxpy>=1.1.15
-statsmodel==0.12.2
+statsmodels==0.12.2


### PR DESCRIPTION
Make clear in docs that the set of `instruments` needs to be set explicitly in config when moving from fixed to estimated instrument weights, & show how to use the keys from `system.config.instrument_weights` to do this simply.

(There were 2 natural points in the docs for this to be explained, select whichever you think is most natural (or both)).

Also `statsmodels` not `statsmodel` in requirements.txt