### PR TITLE
require python 3.7 or higher

### DIFF
--- a/.github/workflows/slow-test.yml
+++ b/.github/workflows/slow-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ 3.9, 3.8, 3.7, 3.6 ]
+        python-version: [ 3.9, 3.8, 3.7 ]
 
     steps:
 

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import platform
 from setuptools import setup, find_packages
 from distutils.version import StrictVersion
 
-if StrictVersion(platform.python_version()) < StrictVersion("3.6.0"):
-    print("pysystemtrade requires Python 3.6.0 or later. Exiting.", file=sys.stderr)
+if StrictVersion(platform.python_version()) <= StrictVersion("3.7.0"):
+    print("pysystemtrade requires Python 3.7.0 or later. Exiting.", file=sys.stderr)
     sys.exit(1)
 
 if StrictVersion(platform.python_version()) >= StrictVersion("3.9.0"):


### PR DESCRIPTION
Python 3.6 reaches end of life on 2021-12-23. Also a recent change broke the slow integration test for 3.6