### PR TITLE
INR and INR-mini to duplicate_instruments

### DIFF
--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -282,6 +282,7 @@ duplicate_instruments:
     gasoiline: 'GASOILINE'
     gold: 'GOLD_micro'
     heatoil: 'HEATOIL'
+    inr: 'INR',
     jgb: 'JGB'
     jpy: 'JPY'
     kospi: 'KOSPI'
@@ -301,6 +302,7 @@ duplicate_instruments:
     gasoiline: 'GASOILINE_mini'
     gold: 'GOLD'
     heatoil: 'HEATOIL_mini'
+    inr: 'INR_mini',
     jgb: ['JGB_mini', 'JGB-SGX-mini']
     jpy: ['JPY_micro','JPY-SGX-TITAN', 'JPY-SGX']
     kospi: 'KOSPI_mini'

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -302,7 +302,7 @@ duplicate_instruments:
     gasoiline: 'GASOILINE_mini'
     gold: 'GOLD'
     heatoil: 'HEATOIL_mini'
-    inr: 'INR_mini',
+    inr: 'INR-mini',
     jgb: ['JGB_mini', 'JGB-SGX-mini']
     jpy: ['JPY_micro','JPY-SGX-TITAN', 'JPY-SGX']
     kospi: 'KOSPI_mini'


### PR DESCRIPTION
INR and INR-mini to `duplicate_instruments` in `sysdata.config.defaults.yaml`, otherwise INR-mini is included as an instrument even though the parent contract is a bad_market.