### PR TITLE
Typos: remove 2 commas

### DIFF
--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -282,7 +282,7 @@ duplicate_instruments:
     gasoiline: 'GASOILINE'
     gold: 'GOLD_micro'
     heatoil: 'HEATOIL'
-    inr: 'INR',
+    inr: 'INR'
     jgb: 'JGB'
     jpy: 'JPY'
     kospi: 'KOSPI'
@@ -302,7 +302,7 @@ duplicate_instruments:
     gasoiline: 'GASOILINE_mini'
     gold: 'GOLD'
     heatoil: 'HEATOIL_mini'
-    inr: 'INR-mini',
+    inr: 'INR-mini'
     jgb: ['JGB_mini', 'JGB-SGX-mini']
     jpy: ['JPY_micro','JPY-SGX-TITAN', 'JPY-SGX']
     kospi: 'KOSPI_mini'


### PR DESCRIPTION
Remove 2 commas that shouldn't be there. My fault: apologies.