### PR TITLE
more robust get_pathname_for_package_from_list using import_module

### DIFF
--- a/syscore/fileutils.py
+++ b/syscore/fileutils.py
@@ -1,6 +1,7 @@
 import glob
 import datetime
 import time
+from importlib import import_module
 import os
 import sys
 
@@ -124,7 +125,7 @@ def get_pathname_for_package_from_list(path_as_list):
     """
     package_name = path_as_list[0]
     paths_or_files = path_as_list[1:]
-    d = os.path.dirname(sys.modules[package_name].__file__)
+    d = os.path.dirname(import_module(package_name).__file__)
 
     if len(paths_or_files) == 0:
         return d

--- a/sysdata/csv/csv_roll_parameters.py
+++ b/sysdata/csv/csv_roll_parameters.py
@@ -6,7 +6,7 @@ from syslogdiag.log_to_screen import logtoscreen
 
 import pandas as pd
 
-ROLLS_DATAPATH = "data.futures.csvconfig."
+ROLLS_DATAPATH = "data.futures.csvconfig"
 ROLLS_CONFIG_FILE = "rollconfig.csv"
 
 


### PR DESCRIPTION
I needed this as when in dev mode I install Python packages using pip in editable mode "pip install -e" which do not seem to be in the sys.modules dict, but do resolve via import_module.