### PR TITLE
Instrument config backup column order

### DIFF
--- a/sysdata/csv/csv_instrument_data.py
+++ b/sysdata/csv/csv_instrument_data.py
@@ -1,3 +1,5 @@
+import dataclasses
+
 from syscore.fileutils import get_filename_for_package
 from sysdata.futures.instruments import futuresInstrumentData
 from syscore.objects import arg_not_supplied
@@ -91,7 +93,11 @@ class csvFuturesInstrumentData(futuresInstrumentData):
         )
 
     def write_all_instrument_data_from_df(self, instrument_data_as_df: pd.DataFrame):
-        instrument_data_as_df.to_csv(self._config_file, index_label="Instrument")
+        instrument_data_as_df.to_csv(
+            self._config_file,
+            index_label="Instrument",
+            columns=[field.name for field in dataclasses.fields(instrumentMetaData)]
+        )
 
 
 def get_instrument_with_meta_data_object(


### PR DESCRIPTION
When you update cost data, it's changing the column order in the instrument config, which makes it difficult to see what has actually changed.

This will use the order of the fields as defined in the instrumentMetaData class.  I'm assuming the dataclasses.fields function will always return them in this order. That seems to be the case, but it probably isn't strictly guaranteed.

Still, I thought this was preferable to hard-coding the column names in another location.