### PR TITLE
Emailing.py & Production Doc typos

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -1448,7 +1448,7 @@ These control the core functionality of the system.
 
 Python:
 ```python
-from sysproduction.updateFxPrices import update_fx_prices
+from sysproduction.update_fx_prices import update_fx_prices
 
 update_fx_prices()
 ```
@@ -1473,7 +1473,7 @@ This ensures that we are currently sampling active contracts, and updates contra
 
 Python:
 ```python
-from sysproduction.update_sampled_contracts import updated_sampled_contracts
+from sysproduction.update_sampled_contracts import update_sampled_contracts
 update_sampled_prices()
 ```
 

--- a/syslogdiag/emailing.py
+++ b/syslogdiag/emailing.py
@@ -68,21 +68,27 @@ def _send_msg(msg):
 
     """
 
-    email_server, email_address, email_pwd, email_to, email_port = get_email_details()
+    email_server, email_address, email_pwd, email_to, email_port, use_gmail = get_email_details()
 
     me = email_address
     you = email_to
     msg["From"] = me
     msg["To"] = you
 
+
     # Send the message via our own SMTP server, but don't include the
     # envelope header.
-    s = smtplib.SMTP(email_server, email_port)
-    # add tls for those using yahoo or gmail. 
-    try:
-        s.starttls()
-    except:
-        pass
+    if use_gmail:
+        s = smtplib.SMTP_SSL(email_server, email_port)
+    else:
+        s = smtplib.SMTP(email_server, email_port)
+    # add tls for those using yahoo or gmail.
+    
+    if use_gmail:
+        try:
+            s.starttls()
+        except:
+            pass
     s.login(email_address, email_pwd)
     s.sendmail(me, [you], msg.as_string())
     s.quit()
@@ -97,7 +103,9 @@ def get_email_details():
         email_server = production_config.email_server
         email_to = production_config.email_to
         email_port = production_config.email_port
+        use_gmail = production_config.use_gmail
+
     except:
         raise Exception("Need to have all of these for email to work in private config: email_address, email_pwd, email_server, email_to", "email_port")
 
-    return email_server, email_address, email_pwd, email_to, email_port
+    return email_server, email_address, email_pwd, email_to, email_port, use_gmail


### PR DESCRIPTION
I needed to make the following changes to the emailing.py file to get it to work with gmail, I've tried to keep it as generic as possible if you're not using gmail

```
    # Send the message via our own SMTP server, but don't include the
    # envelope header.
    if use_gmail:
        s = smtplib.SMTP_SSL(email_server, email_port)
    else:
        s = smtplib.SMTP(email_server, email_port)
    # add tls for those using yahoo or gmail.
    
    if use_gmail:
        try:
            s.starttls()
        except:
            pass
```

Also there were a couple of typos in the names of functions / files in the production doc 