### PR TITLE
Added ability to run optimiseWeightsOverTime.weights() under a multip…

### DIFF
--- a/sysquant/optimisation/optimise_over_time.py
+++ b/sysquant/optimisation/optimise_over_time.py
@@ -8,6 +8,7 @@ from sysquant.fitting_dates import generate_fitting_dates, listOfFittingDates
 from sysquant.optimisation.portfolio_optimiser import portfolioOptimiser
 from sysquant.returns import returnsForOptimisation
 
+from multiprocessing import Pool
 
 class optimiseWeightsOverTime(object):
     def __init__(
@@ -23,11 +24,12 @@ class optimiseWeightsOverTime(object):
         fit_dates = generate_fitting_dates(
             net_returns, date_method=date_method, rollyears=rollyears
         )
-
         optimiser_for_one_period = portfolioOptimiser(net_returns, log=log, **kwargs)
-
         self._fit_dates = fit_dates
         self._optimiser = optimiser_for_one_period
+        self.n_threads = None
+        if 'n_threads' in kwargs:
+            self.n_threads = kwargs['n_threads']
 
     @property
     def fit_dates(self) -> listOfFittingDates:
@@ -40,17 +42,26 @@ class optimiseWeightsOverTime(object):
     def weights(self) -> pd.DataFrame:
         fit_dates = self.fit_dates
         optimiser = self.optimiser
-
+       
         progress = progressBar(len(fit_dates), "Optimising weights")
-
+        
         weight_list = []
+        
         # Now for each time period, estimate weights
-        for fit_period in fit_dates:
-            progress.iterate()
-            weight_dict = optimiser.calculate_weights_for_period(fit_period)
-            weight_list.append(weight_dict)
-
+        if self.n_threads is None:
+            for fit_period in fit_dates:
+                weight_dict = optimiser.calculate_weights_for_period(fit_period)
+                weight_list.append(weight_dict)
+                progress.iterate()
+        else:
+            with Pool(self.n_threads) as p:
+                for i, weight_dict in enumerate(p.imap(optimiser.calculate_weights_for_period, fit_dates), 1):
+                    weight_list.append(weight_dict)
+                    print(i)
+                    progress.iterate()                  
+                   
         weight_index = fit_dates.list_of_starting_periods()
         weights = pd.DataFrame(weight_list, index=weight_index)
+        weights.sort_index(ascending=True, inplace=True)
 
         return weights

--- a/sysquant/returns.py
+++ b/sysquant/returns.py
@@ -54,6 +54,12 @@ class returnsForOptimisation(pd.DataFrame):
         super().__init__(*args, **kwargs)
         self._frequency = frequency
         self._pooled_length = pooled_length
+        # Any additional attributes need to be added into the reduce below
+
+    def __reduce__(self):
+        t = super().__reduce__()
+        t[2].update( {'_is_copy':self._is_copy, '_frequency':self._frequency, '_pooled_length':self._pooled_length } )
+        return t[0], t[1], t[2]
 
     @property
     def frequency(self):

--- a/systems/tests/test_mp_optimise_over_time.py
+++ b/systems/tests/test_mp_optimise_over_time.py
@@ -1,0 +1,66 @@
+"""
+Created on 09 Jan 2022
+
+@author: JLangle
+"""
+import unittest
+from sysquant.optimisation.optimise_over_time import optimiseWeightsOverTime
+from sysquant.returns import returnsForOptimisation
+from sysdata.config.configdata import Config
+
+import pandas as pd
+import numpy as np
+from time import time
+import pickle as pkl
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        index = pd.bdate_range(start='1/1/2000', end='1/08/2020')
+        data = np.random.normal(0,1,(len(index),20))
+        net_returns_df = pd.DataFrame(index=index, data=data)
+
+        self.net_returns = returnsForOptimisation(net_returns_df)
+
+    def test_pickling(self):
+        # multiprocessing needs to pickle; make sure the derived class attributes get set when unpickling
+        
+        # pickle
+        net_returns_pkl_s = pkl.dumps(self.net_returns)
+
+        # unplickle
+        net_returns = pkl.loads(net_returns_pkl_s)
+
+        # attributes after unpicking
+        attrs_after = net_returns.__dict__.keys()
+   
+        self.assertTrue( '_pooled_length' in attrs_after )   
+        self.assertTrue( '_frequency' in attrs_after )   
+
+    def test_mp_optimisation(self):
+        config = Config()
+
+        weighting_params = config.default_config_dict['forecast_weight_estimate']
+
+        n_threads = 8
+        weighting_params['n_threads'] = n_threads # running from a Pool of threads
+
+        start_time1 = time()
+        weights1 = optimiseWeightsOverTime(self.net_returns, **weighting_params).weights()
+        stop_time1 = time()
+
+        
+        del weighting_params['n_threads'] # running in main process, not separate process
+
+        start_time2 = time()
+        weights2 = optimiseWeightsOverTime(self.net_returns, **weighting_params).weights()
+        stop_time2 = time()
+
+        print(f"Takes {stop_time1-start_time1} seconds with {n_threads} processes")
+        print(f"Takes {stop_time2-start_time2} seconds running in main process")
+
+        self.assertTrue( weights1.equals(weights2) )
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Added the ability to run optimiseWeightsOverTime.weights() under a multiprocessing pool with imap.

This provides a substantial speed improvement.

To enable, add n_threads = N  to config.forecast_weight_estimate, where N is the number of processes to use (machine dependent)
