### PR TITLE
Fix pickle error

### DIFF
--- a/systems/basesystem.py
+++ b/systems/basesystem.py
@@ -219,7 +219,7 @@ class System(object):
         config = self.config
         try:
             # if instrument weights specified in config ...
-            instrument_list = config.instrument_weights.keys()
+            instrument_list = list(config.instrument_weights.keys())
         except:
             try:
                 # alternative place if no instrument weights


### PR DESCRIPTION
Now that this result is cached, it causes an error because it is not actually returning a list.  The keys() method returns a dict_keys object, which can't be pickled.