### PR TITLE
fix caching of bad markets - somehow this was returning an emtpy list

### DIFF
--- a/sysdata/config/configdata.py
+++ b/sysdata/config/configdata.py
@@ -12,7 +12,10 @@ trading_rules - a specification of the trading rules for a system
 
 """
 
+from pathlib import Path
+
 import yaml
+
 from syscore.fileutils import get_filename_for_package
 from syscore.objects import missing_data, arg_not_supplied
 from sysdata.config.defaults import get_system_defaults_dict
@@ -113,7 +116,7 @@ class Config(object):
             # its a dict
             self._create_config_from_dict(config_item)
 
-        elif isinstance(config_item, str):
+        elif isinstance(config_item, str) or isinstance(config_item, Path):
             # must be a file YAML'able, from which we load the
             filename = get_filename_for_package(config_item)
             with open(filename) as file_to_parse:

--- a/systems/basesystem.py
+++ b/systems/basesystem.py
@@ -169,7 +169,7 @@ class System(object):
         remove_bad_markets=False,
         remove_short_history=False,
         days_required=750,
-        force_to_passed_list = arg_not_supplied
+        force_to_passed_list=arg_not_supplied,
     ) -> list:
         """
         Get the instrument list
@@ -177,27 +177,29 @@ class System(object):
         :returns: list of instrument_code str
         """
         if force_to_passed_list is not arg_not_supplied:
-            instrument_list =  force_to_passed_list
+            instrument_list = force_to_passed_list
         else:
-            instrument_list = \
-                self._get_instrument_list_from_config(remove_duplicates=remove_duplicates,
+            instrument_list = self._get_instrument_list_from_config(
+                remove_duplicates=remove_duplicates,
                 remove_short_history=remove_short_history,
                 remove_bad_markets=remove_bad_markets,
                 remove_ignored=remove_ignored,
                 remove_trading_restrictions=remove_trading_restrictions,
-                days_required=days_required)
+                days_required=days_required,
+            )
 
         return instrument_list
 
     @base_system_cache()
-    def _get_instrument_list_from_config(self,
-                                         remove_duplicates=True,
-                                         remove_ignored=True,
-                                         remove_trading_restrictions=False,
-                                         remove_bad_markets=False,
-                                         remove_short_history=False,
-                                         days_required=750,
-                                         ) -> list:
+    def _get_instrument_list_from_config(
+        self,
+        remove_duplicates=True,
+        remove_ignored=True,
+        remove_trading_restrictions=False,
+        remove_bad_markets=False,
+        remove_short_history=False,
+        days_required=750,
+    ) -> list:
 
         instrument_list = self._get_raw_instrument_list_from_config()
         instrument_list = self._remove_instruments_from_instrument_list(
@@ -267,7 +269,7 @@ class System(object):
 
         return instrument_list
 
-    @base_system_cache()
+    # @base_system_cache()
     def get_list_of_markets_not_trading_but_with_data(
         self,
         remove_duplicates=True,
@@ -301,7 +303,7 @@ class System(object):
 
         return not_trading_in_instrument_list
 
-    @base_system_cache()
+    # @base_system_cache()
     def get_list_of_instruments_to_remove(
         self,
         remove_duplicates=True,
@@ -338,7 +340,7 @@ class System(object):
 
         return list_to_remove
 
-    @base_system_cache()
+    # @base_system_cache()
     def get_list_of_duplicate_instruments_to_remove(self):
         duplicate_list = get_duplicate_list_of_instruments_to_remove_from_config(
             self.config
@@ -352,7 +354,7 @@ class System(object):
 
         return duplicate_list
 
-    @base_system_cache()
+    # @base_system_cache()
     def get_list_of_ignored_instruments_to_remove(self) -> list:
         ignore_instruments = get_list_of_ignored_instruments_in_config(self.config)
         ignore_instruments.sort()
@@ -364,7 +366,7 @@ class System(object):
 
         return ignore_instruments
 
-    @base_system_cache()
+    # @base_system_cache()
     def get_list_of_markets_with_trading_restrictions(self) -> list:
         trading_restrictions = get_list_of_untradeable_instruments_in_config(
             self.config
@@ -378,7 +380,7 @@ class System(object):
             )
         return trading_restrictions
 
-    @base_system_cache()
+    # @base_system_cache()
     def get_list_of_bad_markets(self) -> list:
         bad_markets = get_list_of_bad_instruments_in_config(self.config)
         bad_markets.sort()
@@ -391,8 +393,8 @@ class System(object):
 
         return bad_markets
 
-    @base_system_cache()
-    def get_list_of_short_history(self, days_required: int=750) -> list:
+    # @base_system_cache()
+    def get_list_of_short_history(self, days_required: int = 750) -> list:
         instrument_list = self.data.get_instrument_list()
 
         too_short = [


### PR DESCRIPTION
As mentioned in here https://github.com/robcarver17/pysystemtrade/discussions/535
Bad markets were returning empty list, setting cache off and then recalling the function then produced the expected list of instruments. I noticed this as VNKI and others kept appearing in the DO positions - this fixes that.