### PR TITLE
Handle 'missing_data' in report date columns

### DIFF
--- a/syscore/pdutils.py
+++ b/syscore/pdutils.py
@@ -20,7 +20,7 @@ from syscore.dateutils import (
     WEEKS_IN_YEAR,
     MONTHS_IN_YEAR,
 )
-from syscore.objects import arg_not_supplied
+from syscore.objects import arg_not_supplied, missing_data
 
 DEFAULT_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
@@ -635,3 +635,11 @@ def quantile_of_points_in_data_series(data_series):
 
     results_series = pd.Series(results, index=data_series.index)
     return results_series
+
+
+def sort_df_ignoring_missing(df, column):
+    # sorts df by column, with rows containing missing_data coming at the end
+    missing = df[df[column] == missing_data]
+    valid = df[df[column] != missing_data]
+    valid_sorted = valid.sort_values(column)
+    return pd.concat([valid_sorted, missing])

--- a/sysproduction/reporting/api.py
+++ b/sysproduction/reporting/api.py
@@ -902,7 +902,9 @@ def filter_data_for_delays(data_with_datetime,
                 max_delay_in_days = 3) -> pd.DataFrame:
 
     max_delay_in_seconds = max_delay_in_days * SECONDS_PER_DAY
-    time_delays = datetime.datetime.now() -data_with_datetime[datetime_colum]
+    # ignore missing data
+    data_with_datetime = data_with_datetime[data_with_datetime[datetime_colum] != missing_data]
+    time_delays = datetime.datetime.now() - data_with_datetime[datetime_colum]
     delayed = [time_difference.total_seconds() > max_delay_in_seconds
                for time_difference in time_delays]
 

--- a/sysproduction/reporting/data/status.py
+++ b/sysproduction/reporting/data/status.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from syscore.genutils import transfer_object_attributes
 from syscore.objects import missing_data
-from syscore.pdutils import make_df_from_list_of_named_tuple
+from syscore.pdutils import make_df_from_list_of_named_tuple, sort_df_ignoring_missing
 from sysobjects.production.tradeable_object import instrumentStrategy
 from sysproduction.data.control_process import dataControlProcess, diagControlProcess
 from sysproduction.data.controls import (
@@ -139,21 +139,21 @@ def get_control_status_list_for_all_processes_as_df(data):
 def get_control_data_list_for_all_methods_as_df(data):
     cd_list = get_control_data_list_for_all_methods(data)
     pdf = make_df_from_list_of_named_tuple(dataForMethod, cd_list)
-    pdf = pdf.sort_values("last_start")
+    pdf = sort_df_ignoring_missing(pdf, "last_start")
     return pdf
 
 
 def get_control_status_list_for_all_methods_as_df(data):
     cd_list = get_control_data_list_for_all_methods(data)
     pdf = make_df_from_list_of_named_tuple(dataForMethod, cd_list)
-    pdf = pdf.sort_values("last_start")
+    pdf = sort_df_ignoring_missing(pdf, "last_start")
     return pdf
 
 
 def get_last_price_updates_as_df(data):
     cd_list = get_list_of_last_price_updates(data)
     pdf = make_df_from_list_of_named_tuple(genericUpdate, cd_list)
-    pdf = pdf.sort_values("last_update")
+    pdf = sort_df_ignoring_missing(pdf, "last_update")
 
     return pdf
 
@@ -161,7 +161,7 @@ def get_last_price_updates_as_df(data):
 def get_last_optimal_position_updates_as_df(data):
     cd_list = get_list_of_last_position_updates(data)
     pdf = make_df_from_list_of_named_tuple(genericUpdate, cd_list)
-    pdf = pdf.sort_values("last_update")
+    pdf = sort_df_ignoring_missing(pdf, "last_update")
 
     return pdf
 


### PR DESCRIPTION
The changes here are to deal with exceptions due to sorting or filtering on report date columns that have values of 'missing_data' instead of dates. This happens when either there is a brand new system where some events have never happened, or events are configured to not run at all.

The change to 'sysproduction/reporting/api.py' does make the exceptions go away, but may not be the best possible solution. In an ideal world, filter_data_for_delays() should return rows that represent events that haven't run but should have. But that would be a much more complex solution