### PR TITLE
Fix progress bar appearance

### DIFF
--- a/syscore/genutils.py
+++ b/syscore/genutils.py
@@ -311,7 +311,7 @@ class progressBar(object):
             time_str = ""
 
         bar = "=" * self.how_many_blocks_had() + "-" * self.how_many_blocks_left()
-        progress_string = "\0\r [%s] %s%s %s %s\n" % (
+        progress_string = "\0\r [%s] %s%s %s %s" % (
             bar,
             percents,
             "%",


### PR DESCRIPTION
Thank you Robert for this awesome work.

This pull request fixes an annoying bug that causes the progress bar to keep scrolling the output (due to the '\n' that should not be there). The change just makes the scrollbar behave the way it should be (redrawn on the same line).