### PR TITLE
Factor hardcoded IB class list out of broker.py

### DIFF
--- a/sysbrokers/broker_factory.py
+++ b/sysbrokers/broker_factory.py
@@ -1,0 +1,47 @@
+from sysbrokers.IB.ib_capital_data import ibCapitalData
+from sysbrokers.IB.ib_Fx_prices_data import ibFxPricesData
+from sysbrokers.IB.ib_futures_contract_price_data import ibFuturesContractPriceData
+from sysbrokers.IB.ib_futures_contracts_data import ibFuturesContractData
+from sysbrokers.IB.ib_instruments_data import ibFuturesInstrumentData
+from sysbrokers.IB.ib_contract_position_data import ibContractPositionData
+from sysbrokers.IB.ib_orders import ibExecutionStackData
+from sysbrokers.IB.ib_static_data import ibStaticData
+from sysbrokers.IB.ib_fx_handling import ibFxHandlingData
+from syscore.objects import missing_data, resolve_function
+from sysdata.config.production_config import get_production_config
+
+
+def get_broker_class_list():
+    """
+    Returns a list of classes that are specific to the broker being used.
+    IB classes are returned by default. If you would like to use a different
+    broker, then create a custom get_class_list() function in your private
+    directory and specify the function name in private_config.yaml under the
+    field name: broker_factory_func
+    """
+    config = get_production_config()
+
+    broker_factory_func = config.get_element_or_missing_data('broker_factory_func')
+
+    if broker_factory_func is missing_data:
+        get_class_list = get_ib_class_list
+    else:
+        get_class_list = resolve_function(broker_factory_func)
+
+    broker_class_list = get_class_list()
+
+    return broker_class_list
+
+
+def get_ib_class_list():
+    return [
+        ibFxPricesData,
+        ibFuturesContractPriceData,
+        ibFuturesContractData,
+        ibContractPositionData,
+        ibExecutionStackData,
+        ibStaticData,
+        ibCapitalData,
+        ibFuturesInstrumentData,
+        ibFxHandlingData,
+    ]

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -33,6 +33,9 @@ ib_ipaddress: 127.0.0.1
 ib_port: 4001
 ib_idoffset: 100
 #
+# Broker class list resolution function
+broker_factory_func: 'sysbrokers.broker_factory.get_ib_class_list'
+#
 # Mongo DB
 mongo_host: 127.0.0.1
 mongo_db: 'production'

--- a/sysproduction/data/broker.py
+++ b/sysproduction/data/broker.py
@@ -1,14 +1,6 @@
 from copy import copy
-from sysbrokers.IB.ib_capital_data import ibCapitalData
-from sysbrokers.IB.ib_Fx_prices_data import ibFxPricesData
-from sysbrokers.IB.ib_futures_contract_price_data import ibFuturesContractPriceData
-from sysbrokers.IB.ib_futures_contracts_data import ibFuturesContractData
-from sysbrokers.IB.ib_instruments_data import ibFuturesInstrumentData
-from sysbrokers.IB.ib_contract_position_data import ibContractPositionData
-from sysbrokers.IB.ib_orders import ibExecutionStackData
-from sysbrokers.IB.ib_static_data import ibStaticData
-from sysbrokers.IB.ib_fx_handling import ibFxHandlingData
 
+from sysbrokers.broker_factory import get_broker_class_list
 from sysbrokers.broker_fx_handling import brokerFxHandlingData
 from sysbrokers.broker_static_data import brokerStaticData
 from sysbrokers.broker_execution_stack import brokerExecutionStackData
@@ -51,22 +43,12 @@ from sysproduction.data.generic_production_data import productionDataLayerGeneri
 
 class dataBroker(productionDataLayerGeneric):
     def _add_required_classes_to_data(self, data) -> dataBlob:
-        ## Modify these to use another broker
-        ## These will be aliased as self.data.broker_fx_prices, self.data.broker_futures_contract_price ... and so on
-        data.add_class_list(
-            [
-                ibFxPricesData,
-                ibFuturesContractPriceData,
-                ibFuturesContractData,
-                ibContractPositionData,
-                ibExecutionStackData,
-                ibStaticData,
-                ibCapitalData,
-                ibFuturesInstrumentData,
-                ibFxHandlingData,
-            ]
-        )
 
+        # Add a list of broker specific classes that will be aliased as self.data.broker_fx_prices,
+        # self.data.broker_futures_contract_price ... and so on
+
+        broker_class_list = get_broker_class_list()
+        data.add_class_list(broker_class_list)
         return data
 
     @property


### PR DESCRIPTION
A small refactoring that allows for specifying the broker class list from the `private` folder without having to modify `broker.py`, while maintaining the default behavior 