### PR TITLE
Fix: Allow run_strategy_order_generator to run

### DIFF
--- a/syscontrol/control_config.yaml
+++ b/syscontrol/control_config.yaml
@@ -10,7 +10,7 @@ process_configuration_start_time:
   run_reports: '20:25'
 process_configuration_stop_time:
   default: '23:50'
-  run_strategy_order_generator: '19:30'
+  run_strategy_order_generator: '23:50'
   run_stack_handler: '19:45'
   run_capital_update: '19:50'
   run_daily_prices_updates: '23:50'


### PR DESCRIPTION
The way it is configured now (stop_time < start_time),
run_strategy_order_generator can never run with the default settings. This fix
solves that issue by setting the stop time to a reasonable value (before
midnight).