### PR TITLE
Refactor account_test

### DIFF
--- a/syscore/accounting.py
+++ b/syscore/accounting.py
@@ -37,8 +37,8 @@ def account_test(
     """
 
     # Inner join on the cumulative returns
-    acc1_ = acc1.cumsum()
-    acc2_ = acc2.cumsum()
+    acc1_ = pd.DataFrame(acc1).cumsum()
+    acc2_ = pd.DataFrame(acc2).cumsum()
     cum = pd.merge(acc1_, acc2_, left_index=True, right_index=True)
     cum = cum.sort_index(ascending=True, inplace=False)
 


### PR DESCRIPTION
Hi Rob,

Really enjoyed Systematic Trading and have wanted to get involved with this repo for a while. This function looked like an easy one to get going with. I'm assuming (as I think you do) that both arguments are one-dimensional, especially since `accountCurve` inherits from `pd.Series`. 

Instead of reindexing both series separately, I just replaced this with an inner join, to get rid of intersecting the indices. Then the only missing value should surely be at the start, coming from doing the `.diff()` so the two comprehensions can be condensed. 

I also handled the edge case of the possibility that the series are flat (i.e. standard deviation = 0) with a little epsilon. 

Finally, I tidied up the docstrings and packaged the output into a NamedTuple, so that we do `.pvalue` instead of `[1].pvalue` to access the p-value from the output. Just thought it was a tad cleaner.

Let me know what you think. 

Best,
Sam NB