### PR TITLE
Sleep between checks while waiting to start

### DIFF
--- a/syscontrol/run_process.py
+++ b/syscontrol/run_process.py
@@ -156,6 +156,8 @@ def _start_or_wait(process_to_run: processToRun) -> status:
         if not okay_to_wait:
             return failure
 
+        time.sleep(60)
+
 
 def _is_okay_to_start(process_to_run: processToRun) -> bool:
     """


### PR DESCRIPTION
It wastes a lot of CPU cycles to do check the start conditions continuously.  Can be problematic if you don't have a lot of cores, or if you have multiple processes doing this.

60s seems reasonable to me, since start times are defined in 1 minute increments.

A minor downside is that a process waiting to start won't respond to a STOP signal for up to 60s, but I assume you would be OK with that since you already have the potential for much longer delays when a process is waiting to run its next method.