### PR TITLE
_data_name should be a property

### DIFF
--- a/sysdata/mongodb/mongo_capital.py
+++ b/sysdata/mongodb/mongo_capital.py
@@ -15,5 +15,6 @@ class mongoCapitalData(capitalData, mongoListOfEntriesData):
     def _collection_name(self):
         return CAPITAL_COLLECTION
 
+    @property
     def _data_name(self):
         return "mongoCapitalData"

--- a/sysdata/mongodb/mongo_position_by_contract.py
+++ b/sysdata/mongodb/mongo_position_by_contract.py
@@ -15,5 +15,6 @@ class mongoContractPositionData(contractPositionData, mongoListOfEntriesData):
     def _collection_name(self):
         return POSITION_CONTRACT_COLLECTION
 
+    @property
     def _data_name(self):
         return "mongoContractPositionData"

--- a/sysdata/mongodb/mongo_positions_by_strategy.py
+++ b/sysdata/mongodb/mongo_positions_by_strategy.py
@@ -15,5 +15,6 @@ class mongoStrategyPositionData(strategyPositionData, mongoListOfEntriesData):
     def _collection_name(self):
         return POSITION_STRATEGY_COLLECTION
 
+    @property
     def _data_name(self):
         return "mongoStrategyPositionData"


### PR DESCRIPTION
mongoOptimalPositionData has this, but the other classes that inherit from mongoListOfEntriesData don't.

It's used in mongoListOfEntriesData.__repr__