### PR TITLE
Check for missing_order, not missing_data

### DIFF
--- a/sysproduction/data/orders.py
+++ b/sysproduction/data/orders.py
@@ -217,7 +217,7 @@ class dataOrders(object):
         contract_order = self.get_parent_contract_order_for_historic_broker_order_id(
             order_id
         )
-        if contract_order is missing_data:
+        if contract_order is missing_order:
             return missing_order
 
         instrument_order_id = contract_order.parent


### PR DESCRIPTION
As far as I can see, get_parent_contract_order_for_historic_broker_order_id returns missing_order, not missing_data.

It definitely returns missing_order.  If there is a situation that I'm not seeing where it could also return missing_data, that would either need to be changed or also checked for here.