### PR TITLE
Show roll report in more scenarios

### DIFF
--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -294,6 +294,7 @@ def auto_selected_roll_state_instrument(
 
     if roll_data.relative_volume < auto_parameters.min_volume:
 
+        run_roll_report(data, roll_data.instrument_code)
         print_with_landing_strips_around(
             "For %s relative volume of %f is less than minimum of %s : NOT AUTO ROLLING"
             % (
@@ -307,6 +308,7 @@ def auto_selected_roll_state_instrument(
     no_position_held = roll_data.position_priced_contract == 0
 
     if no_position_held:
+        run_roll_report(data, roll_data.instrument_code)
         print_with_landing_strips_around(
             "No position held, auto rolling adjusted price for %s"
             % roll_data.instrument_code


### PR DESCRIPTION
Just a suggestion, something I found useful.

Show the roll report when:

1) It's time to consider rolling, but the volume in the forward contract isn't there yet - probably fine, but might indicate a problem with roll config, or maybe you will want to roll anyway for low-volume contracts that are priced but not traded.  I like to see the roll report here, so I can see exactly what is going on.

2) No position held (might be getting ready to automatically roll).  When I'm manually confirming the roll, sometimes I also want to see the roll report.