### PR TITLE
subscription test

### DIFF
--- a/examples/data/subscription_test.py
+++ b/examples/data/subscription_test.py
@@ -1,0 +1,54 @@
+import asyncio
+import logging
+from typing import Dict
+from typing import List
+
+import ib_insync
+from ib_insync import ContractDetails
+from ib_insync import Future
+from ib_insync import IB
+
+from sysbrokers.IB.ib_instruments_data import IBconfig
+from sysbrokers.IB.ib_instruments_data import read_ib_config_from_file
+
+HOSTNAME = "localhost"
+
+
+async def subscription_test(
+    ib_symbols: List[str], ib_config: IBconfig
+) -> Dict[str, List[ContractDetails]]:
+    ib_insync.util.logToConsole(logging.INFO)
+    ib = IB()
+    failed = []
+    exceptions = []
+    try:
+        await ib.connectAsync(host=HOSTNAME, port=4001, clientId=1)
+        coros = []
+        for ib_symbol in ib_symbols:
+            try:
+                ib_exchange = ib_config[
+                    ib_config.IBSymbol == ib_symbol
+                ].IBExchange.item()
+                f = Future(symbol=ib_symbol, exchange=ib_exchange, includeExpired=True)
+                coros.append(ib.reqContractDetailsAsync(f))
+            except Exception as e:
+                failed.append(ib_symbol)
+                exceptions.append(str(e))
+        results = await asyncio.gather(*coros)
+        data = {ib: sorted_ContractDetails(cd) for ib, cd in zip(ib_symbols, results)}
+    finally:
+        ib.disconnect()
+    return data, failed, exceptions
+
+
+def sorted_ContractDetails(contract_details: List[ContractDetails]):
+    return sorted(contract_details, key=lambda x: x.realExpirationDate)
+
+
+def main():
+    ib_config: IBconfig = read_ib_config_from_file()
+    return asyncio.run(subscription_test(ib_config.IBSymbol.tolist(), ib_config))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Here I test the subscriptions for the symbols in ib_config_futures.csv
Of the 407 in the file 384 can get data for using my minimal pysystemtrade subscriptions! Pretty cool!
I think the ones that failed are due to duplication in the config, e.g. AEX and AEX_mini have the same IBSymbol.

BTW using the asyncio coroutines of ib_insync is way faster than the plodding serial version. The script takes seconds! 