### PR TITLE
git ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ restats
 
 # venv
 env/
+venv/
 
 # libreoffice
 .~lock.*


### PR DESCRIPTION
@bug-or-feature you added "env/" here.  PyCharm's default folder for virtual environments appears to be "venv/" (but of course you could call it anything).

Shouldn't hurt to have both in any case, to make things work nicely with PyCharm out of the box.