### PR TITLE
Sync numpy requirement with setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas==1.0.5
 matplotlib>=3.0.0
 pyyaml==5.4
-numpy>1.19.4
+numpy>=1.19.4
 scipy>=1.0.0
 pymongo==3.9.0
 arctic==1.79.2


### PR DESCRIPTION
I think this is what you want here.  It's what is in setup.py, and I've been using 1.19.4 for a long time without any obvious issues.  I assume this was just a minor mistake.