### PR TITLE
Handle unexpected asset classes without failing

### DIFF
--- a/sysbrokers/IB/ib_positions.py
+++ b/sysbrokers/IB/ib_positions.py
@@ -52,8 +52,10 @@ def from_ib_positions_to_dict(
 
         asset_class = position.contract.secType
         method = position_methods.get(asset_class, None)
-        if method is None:
-            raise Exception("Can't find asset class %s in methods dict" % asset_class)
+        if method is None:            
+            # Resolve unexpected asset classes like cash rather than failing
+            method = resolve_ib_cash_position
+            # raise Exception("Can't find asset class %s in methods dict" % asset_class)
 
         resolved_position = method(position)
         asset_class_list = resolved_positions_dict.get(asset_class, [])


### PR DESCRIPTION
IB has a lot of possible values that could be returned here.  

I think it's preferable to just resolve a minimal set of properties like you do for cash, so people with other assets in their IB account don't have to make code changes.

However, I would understand if you prefer an exception to be raised.