### PR TITLE
Handle the case when `failure` is returned

### DIFF
--- a/sysinit/futures/seed_price_data_from_IB.py
+++ b/sysinit/futures/seed_price_data_from_IB.py
@@ -8,6 +8,8 @@ from sysdata.arctic.arctic_futures_per_contract_prices import (
     arcticFuturesContractPriceData,
 )
 
+from syscore.objects import failure
+
 
 def seed_price_data_from_IB(instrument_code):
     data = dataBlob()
@@ -36,7 +38,7 @@ def seed_price_data_for_contract(data: dataBlob, contract: futuresContract):
     prices = data.broker_futures_contract_price.get_prices_at_frequency_for_potentially_expired_contract_object(
         new_contract
     )
-    if len(prices) == 0:
+    if prices is failure or len(prices) == 0:
         print("No data!")
     else:
         ## If you want to modify this script so it updates existing prices


### PR DESCRIPTION
I was tempted to unify the error cases and always return an empty `futureContractPrices`, but I didn't know what other code relied on this behaviour.

```
    def _get_prices_at_frequency_for_ibcontract_object_no_checking(
        self,
        contract_object_with_ib_broker_config,
        freq: Frequency,
        allow_expired: bool = False,
    ) -> futuresContractPrices:

        new_log = contract_object_with_ib_broker_config.log(self.log)

        price_data = self.ib_client.broker_get_historical_futures_data_for_contract(
            contract_object_with_ib_broker_config,
            bar_freq=freq,
            allow_expired=allow_expired,
        )

        if price_data is missing_data:
            new_log.warn(
                "Something went wrong getting IB price data for %s"
                % str(contract_object_with_ib_broker_config)
            )
            return failure

        if len(price_data) == 0:
            new_log.warn(
                "No IB price data found for %s"
                % str(contract_object_with_ib_broker_config)
            )
            return futuresContractPrices.create_empty()

        return futuresContractPrices(price_data)

```