### PR TITLE
Adds adjustment of GMT time zone for users in other timezones

### DIFF
--- a/sysbrokers/IB/ib_trading_hours.py
+++ b/sysbrokers/IB/ib_trading_hours.py
@@ -3,6 +3,7 @@ from ib_insync import ContractDetails as ibContractDetails
 
 from syscore.dateutils import adjust_trading_hours_conservatively, openingTimesAnyDay, openingTimes, listOfOpeningTimes
 
+from sysdata.config.production_config import get_production_config
 
 def get_conservative_trading_hours(ib_contract_details: ibContractDetails) -> listOfOpeningTimes:
     time_zone_id = ib_contract_details.timeZoneId
@@ -163,7 +164,18 @@ def get_conservative_trading_time_for_time_zone(time_zone_id: str) -> openingTim
 
     return openingTimesAnyDay(conservative_start_time,
                               conservative_end_time)
-
+def get_GMT_offset_hours():
+    #
+    # GMT_offset_hours = 0 as Default in sysdata.config.defaults.yaml
+    # or set in  private_config.YAML
+    #example
+    # GMT_offset_hours = 6 # for US Central Time, no daylight savings
+    try:
+        production_config = get_production_config()
+        GMT_offset_hours = production_config.GMT_offset_hours
+    except:
+        raise Exception("Default is zero, have it in private_config")
+    return GMT_offset_hours
 
 def get_time_difference(time_zone_id: str) -> int:
     # Doesn't deal with DST. We will be conservative and only trade 1 hour

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -47,6 +47,9 @@ mongo_port: 27017
 echo_extension: '.txt'
 # Spike checker
 max_price_spike: 8.0
+#GMT_offset_hours adjusts GMT to user time zone
+# adjusting market hours in sysbrokers.IB.ib_trading_hours.py
+GMT_offset_hours: 0
 # Behaviour of price filtering
 ignore_future_prices: True
 ignore_prices_with_zero_volumes_intraday: True


### PR DESCRIPTION
This adds a function get GMT_offset_hours that calls from private_config or the default (which is zero) from sysdata.config.defaults.yaml the variable equal to the GMT offset for the users timezone. 
I also modified the function get_time_difference to adjust the time_diff_dict by the offset. 


