### PR TITLE
added GMT_offset_hours to enable user to set timezone difference

### DIFF
--- a/sysbrokers/IB/ib_trading_hours.py
+++ b/sysbrokers/IB/ib_trading_hours.py
@@ -3,6 +3,7 @@ from ib_insync import ContractDetails as ibContractDetails
 
 from syscore.dateutils import adjust_trading_hours_conservatively, openingTimesAnyDay, openingTimes, listOfOpeningTimes
 
+from sysdata.config.production_config import get_production_config
 
 def get_conservative_trading_hours(ib_contract_details: ibContractDetails) -> listOfOpeningTimes:
     time_zone_id = ib_contract_details.timeZoneId
@@ -163,7 +164,16 @@ def get_conservative_trading_time_for_time_zone(time_zone_id: str) -> openingTim
 
     return openingTimesAnyDay(conservative_start_time,
                               conservative_end_time)
-
+def get_GMT_offset_hours():
+    # this needs to be in private_config.YAML
+    # where are the defaults stored that needs to be
+    # GMT_offset_hours = 0
+    try:
+        production_config = get_production_config()
+        GMT_offset_hours = production_config.GMT_offset_hours
+    except:
+        raise Exception("Default is zero, have it in private_config")
+    return GMT_offset_hours
 
 def get_time_difference(time_zone_id: str) -> int:
     # Doesn't deal with DST. We will be conservative and only trade 1 hour
@@ -184,6 +194,9 @@ def get_time_difference(time_zone_id: str) -> int:
         "Hongkong": -7,
         "": 0,
     }
+    GMT_offset_hours = GMT_offset_hours
+    for k, v in time_diff_dict.items():
+        time_diff_dict[k] = v + GMT_offset_hours
     diff_hours = time_diff_dict.get(time_zone_id, None)
     if diff_hours is None:
         raise Exception("Time zone '%s' not found!" % time_zone_id)

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -47,6 +47,8 @@ mongo_port: 27017
 echo_extension: '.txt'
 # Spike checker
 max_price_spike: 8.0
+# Default get_GMT_offset_hours
+GMT_offset_hours: 0
 # Behaviour of price filtering
 ignore_future_prices: True
 ignore_prices_with_zero_volumes_intraday: True


### PR DESCRIPTION
#### Reference Issue
As set up the system uses GMT as the default time zone

#### What does this implement 
This allows a user to add to private_config a GMT offset in hours to allow trading in the users timezone. 

#### Other comments 
Modified  sysbrokers/IB/ib_trading_hours.py
Added a function (get_GMT_offset_hours) to call variable from private_config or defaults.yaml (where default is zero)
modified the function get_time_difference to update the time_diff_dict with the GMT_offset_hours
User must change private_config.yaml to add 
GMT_offset_hours: -6 # as example for US Central time
