### PR TITLE
Some mistakes in pointsizes?

### DIFF
--- a/data/futures/csvconfig/instrumentconfig.csv
+++ b/data/futures/csvconfig/instrumentconfig.csv
@@ -339,8 +339,8 @@ SPI200,25,0,5,0,Equity,AUD,ASX SPI200 Index,1
 STEEL,20,0,0.85,0,Metals,USD,Hot-Rolled Coil Steel Index,5.5
 STERLING3,1250,0,1.7,0,Bond,GBP,3 month Sterling interest rate,0.0025
 SUGAR_WHITE,50,,,,Ags,USD,White sugar,
-SUGAR11,112000,0,3,0,Ags,USD,Sugar #11,5E-05
-SUGAR16,112000,,,,Ags,USD,Sugar #16,
+SUGAR11,1120,0,3,0,Ags,USD,Sugar #11,5E-05
+SUGAR16,1120,,,,Ags,USD,Sugar #16,
 SWISSLEAD,10,,,,Equity,CHF,Swiss Leader Index (PREIS_INDEX),
 TECH60_small,100,,,,Equity,USD,Small Technology 60,
 TIN_LME,5,,,,Metals,USD,Tin – LME,

--- a/data/futures/csvconfig/instrumentconfig.csv
+++ b/data/futures/csvconfig/instrumentconfig.csv
@@ -59,7 +59,7 @@ COAL,1000,,,,OilGas,USD,ICE Rotterdam Coal,
 COAL-GEORDIE,1000,,,,OilGas,USD,ICE Coals to Newcastle,
 COCOA,10,0,3,0,Ags,USD,Cocoa NY,0.5
 COCOA_LDN,10,,,,Ags,GBP,Cocoa London,
-COFFEE,37500,0,3,0,Ags,USD,Coffee,0.001
+COFFEE,375,0,3,0,Ags,USD,Coffee,0.001
 COPPER,25000,0,2.31,0,Metals,USD,Copper,0.000423883318893
 COPPER_LME,25,,,,Metals,USD,Grade A Copper - LME,
 COPPER-micro,2500,,,,Metals,USD,Copper micro,

--- a/data/futures/csvconfig/instrumentconfig.csv
+++ b/data/futures/csvconfig/instrumentconfig.csv
@@ -66,8 +66,8 @@ COPPER-micro,2500,,,,Metals,USD,Copper micro,
 COPPER-mini,12500,0,0.85,0,Metals,USD,COMEX MINY Copper,0.002
 CORN,50,0,2.9,0,Ags,USD,Corn,0.125
 CORN_mini,10,0,2.9,0,Ags,USD,Corn mini,0.125
-COTTON,50000,0,0.85,0,Ags,USD,NYMEX Cotton index,0.2
-COTTON2,50000,0,3,0,Ags,USD,Cotton #2,0.01
+COTTON,500,0,0.85,0,Ags,USD,NYMEX Cotton index,0.2
+COTTON2,500,0,3,0,Ags,USD,Cotton #2,0.01
 CRUDE_ICE,1000,,,,OilGas,USD,West Texas Intermediate Light Sweet Crude Oil ICE,
 CRUDE_W,1000,0,2.31,0,OilGas,USD,Light sweet crude Winter,0.009711689350737
 CRUDE_W_micro,100,0,0.7,0,OilGas,USD,micro WTI crude oil,0.01

--- a/data/futures/csvconfig/instrumentconfig.csv
+++ b/data/futures/csvconfig/instrumentconfig.csv
@@ -291,7 +291,7 @@ NOK,2000000,0,1.5,0,FX,USD,NOKUSD currency,3E-05
 NZD,100000,0,2.46,0,FX,USD,NZDUSD currency,5.8E-05
 OAT,1000,0,2,0,Bond,EUR,French 10 year bond OAT,0.005
 OATIES,50,0,1.5,0,Ags,USD,Oat Futures,1.5
-OJ,15000,0,3,0,Ags,USD,Orange Juice (FCOJ-A),0.01075
+OJ,150,0,3,0,Ags,USD,Orange Juice (FCOJ-A),0.01075
 OMX,10,0,2,0,Equity,EUR,OMX Helsinki 25 Index,11.75
 OMXESG,100,,,,Equity,EUR,OMXS30 ESG Responsible Index,
 PALLAD,100,0,2.31,0,Metals,USD,Palladium,2


### PR DESCRIPTION
Hi Rob,

Could it be that the data for some pointsizes in your system are wrong? (I'm not sure how much you care about these data, of course.)

For example, I currently see a $50,000 pointsize in your system for cotton. By contrast, when I look at Barchart, I see a pointsize of $500 rather than $50,000:
https://www.barchart.com/futures/quotes/KG*0
https://www.barchart.com/futures/quotes/CT*0
It's the contract size that's 50,000lbs.

Similarly, the pointsizes for coffee, OJ and sugar seem wrong and I have corrected them based on what I see on Barchart. (Again they seem to have  confused the contract size and pointsize on Barchart.) I have also not checked other data like PerBlock or Slippage for any of these instruments. I have also not checked the pointsizes for all instruments, just for a subset that I happened to be interested in.

Thanks so much for all your work on this fantastic library and for all the wonderful books and podcasts you produce! I feel like I've learnt so much from them!

Matthijs

PS It's interesting to note that Barchart appears to not always be accurate. For example, it lists a point value of 5,000 for SILVER, while it seems to be 1,000 in reality: https://www.barchart.com/futures/quotes/SI*0/overview