### PR TITLE
ib.reqCurrentTime() and TWS 10.16 fix

### DIFF
--- a/sysbrokers/IB/client/ib_client.py
+++ b/sysbrokers/IB/client/ib_client.py
@@ -102,10 +102,3 @@ class ibClient(object):
 
     def refresh(self):
         self.ib.sleep(0.00001)
-
-    def get_broker_time_local_tz(self) -> datetime.datetime:
-        ib_time = self.ib.reqCurrentTime()
-        local_ib_time_with_tz = ib_time.astimezone(tz.tzlocal())
-        local_ib_time = strip_timezone_fromdatetime(local_ib_time_with_tz)
-
-        return local_ib_time

--- a/sysbrokers/IB/client/ib_price_client.py
+++ b/sysbrokers/IB/client/ib_price_client.py
@@ -25,6 +25,7 @@ from sysobjects.contracts import futuresContract
 from sysexecution.trade_qty import tradeQuantity
 
 
+
 class tickerWithBS(object):
     def __init__(self, ticker, BorS: str):
         self.ticker = ticker
@@ -146,10 +147,10 @@ class ibPriceClient(ibContractsClient):
             )
             return missing_contract
 
-        recent_ib_time = self.ib.reqCurrentTime() - datetime.timedelta(seconds=60)
+        recent_time = datetime.datetime.now() - datetime.timedelta(seconds=60)
 
         tick_data = self.ib.reqHistoricalTicks(
-            ibcontract, recent_ib_time, "", tick_count, "BID_ASK", useRth=False
+            ibcontract, recent_time, "", tick_count, "BID_ASK", useRth=False
         )
 
         return tick_data

--- a/sysbrokers/IB/client/ib_price_client.py
+++ b/sysbrokers/IB/client/ib_price_client.py
@@ -25,7 +25,6 @@ from sysobjects.contracts import futuresContract
 from sysexecution.trade_qty import tradeQuantity
 
 
-
 class tickerWithBS(object):
     def __init__(self, ticker, BorS: str):
         self.ticker = ticker

--- a/sysbrokers/IB/ib_orders.py
+++ b/sysbrokers/IB/ib_orders.py
@@ -2,6 +2,8 @@ from ib_insync import Trade as ibTrade
 
 from copy import copy
 
+import datetime
+
 from sysbrokers.IB.ib_futures_contracts_data import ibFuturesContractData
 from sysbrokers.IB.ib_instruments_data import ibFuturesInstrumentData
 from sysbrokers.IB.ib_translate_broker_order_objects import (
@@ -259,7 +261,7 @@ class ibExecutionStackData(brokerExecutionStackData):
         :return: ibOrderWithControls or missing_order
         """
         trade_with_contract_from_ib = self._send_broker_order_to_IB(broker_order)
-        order_time = self.ib_client.get_broker_time_local_tz()
+        order_time = datetime.datetime.now()
 
         if trade_with_contract_from_ib is missing_order:
             return missing_order


### PR DESCRIPTION
There seems to be [documented](https://github.com/erdewit/ib_insync/issues/479) faulty behaviour of ib.reqCurrentTime when using the latest version of IB TWS (build 10.16). This breaks pysystemtrade (notably the stack handler no longer works).

The discussion [here](https://github.com/erdewit/ib_insync/issues/479) makes a good point that there is nothing special about the system time that reqCurrentTime returns. It should just return the time according to the IB servers in the timezone set in TWS (default your local timezone). I propose to just use the local system time instead. The fewer async requests to the IB servers the better is my thinking. That's what I've implemented in this PR and it works fine, it seems. What do you think?