### PR TITLE
Fixing order in which start_date is resolved

### DIFF
--- a/syscore/dateutils.py
+++ b/syscore/dateutils.py
@@ -601,18 +601,18 @@ def calculate_start_and_end_dates(
         end_date = get_date_from_period_and_end_date(end_period)
 
     ## DO THE START DATE NEXT
-    ## First preference is to use period, then calendar days, then passed date
+    ## First preference is to use period, then passed date, then calendar days
     if start_period is arg_not_supplied:
-        if calendar_days_back is arg_not_supplied:
+        if start_date is arg_not_supplied:
             ## no period or calendar days, use passed date
-            if start_date is arg_not_supplied:
+            if calendar_days_back is arg_not_supplied:
                 raise Exception("Have to specify one of calendar days back, start period or start date!")
             else:
-                ## Use passed start date
-                pass
+                ## Calendar days
+                start_date = n_days_ago(calendar_days_back, end_date)
         else:
-            ## Calendar days
-            start_date = n_days_ago(calendar_days_back, end_date)
+            ## Use passed start date
+            pass
     else:
         ## have a period
         start_date = get_date_from_period_and_end_date(start_period, end_date)


### PR DESCRIPTION
I believe the order in which the start date for trade, slippage and pandl reports was resolved was wrong. It used to try calendar_days_back first. (Used by run_reports.) But I think it should try start_date first if we want interactive_diagnostics reports to work with custom start dates. Indeed, the old behaviour was that reports were always produced with the start date being set to a default (1 or 250 days before the end date) when using interactive_diagnostics. This PR fixes that problem and it makes sure that both the defaults of run_reports work as well as custom start dates supplied in interactive_diagnostics.

