### PR TITLE
Fix cost index order

### DIFF
--- a/systems/accounts/pandl_calculators/pandl_calculation_dict.py
+++ b/systems/accounts/pandl_calculators/pandl_calculation_dict.py
@@ -101,7 +101,7 @@ class dictOfPandlCalculatorsWithGenericCosts(dict):
 
 
 def sum_list_of_pandl_curves(list_of_pandl_curves: list):
-    df_of_pandl_curves = pd.concat(list_of_pandl_curves, axis=1)
+    df_of_pandl_curves = pd.concat(list_of_pandl_curves, axis=1, sort=True)
     summed_pandl_curve = df_of_pandl_curves.sum(axis=1)
 
     return summed_pandl_curve


### PR DESCRIPTION
Hi Rob,

Since pandas 1.0, the `pd.concat` doesn't sort the index. That results in an error like the following:

```
  File "/usr/local/lib/python3.8/site-packages/systems/system_cache.py", line 723, in wrapper
    ans = system.cache.calc_or_cache(
  File "/usr/local/lib/python3.8/site-packages/systems/system_cache.py", line 573, in calc_or_cache
    value = func(this_stage, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/systems/accounts/account_portfolio.py", line 50, in portfolio
    account_curve = accountCurveGroup(
  File "/usr/local/lib/python3.8/site-packages/systems/accounts/curves/account_curve_group.py", line 22, in __init__
    super().__init__(total_pandl_calculator, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/systems/accounts/curves/account_curve.py", line 30, in __init__
    as_pd_series = pandl_calculator_with_costs.as_pd_series_for_frequency(
  File "/usr/local/lib/python3.8/site-packages/systems/accounts/pandl_calculators/pandl_calculation.py", line 59, in as_pd_series_for_frequency
    as_pd_series = self.as_pd_series(**kwargs)
  File "/usr/local/lib/python3.8/site-packages/systems/accounts/pandl_calculators/pandl_generic_costs.py", line 35, in as_pd_series
    return self.net_pandl_in_base_currency()
  File "/usr/local/lib/python3.8/site-packages/systems/accounts/pandl_calculators/pandl_generic_costs.py", line 64, in net_pandl_in_base_currency
    net = _add_gross_and_costs(gross, costs)
  File "/usr/local/lib/python3.8/site-packages/systems/accounts/pandl_calculators/pandl_generic_costs.py", line 108, in _add_gross_and_costs
    cumsum_costs_aligned = cumsum_costs.reindex(gross.index, method="ffill")
  File "/usr/local/lib/python3.8/site-packages/pandas/core/series.py", line 4672, in reindex
    return super().reindex(**kwargs)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/generic.py", line 4966, in reindex
    return self._reindex_axes(
  File "/usr/local/lib/python3.8/site-packages/pandas/core/generic.py", line 4981, in _reindex_axes
    new_index, indexer = ax.reindex(
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 4215, in reindex
    indexer = self.get_indexer(
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3792, in get_indexer
    return self._get_indexer(target, method, limit, tolerance)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3805, in _get_indexer
    indexer = self._get_fill_indexer(target, method, limit, tolerance)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3913, in _get_fill_indexer
    indexer = self._get_fill_indexer_searchsorted(target, method, limit)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3937, in _get_fill_indexer_searchsorted
    indexer[nonexact] = self._searchsorted_monotonic(target[nonexact], side)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 6370, in _searchsorted_monotonic
    raise ValueError("index must be monotonic increasing or decreasing")
ValueError: index must be monotonic increasing or decreasing
```