### PR TITLE
Don't cumsum/diff during pd.Series resampling

### DIFF
--- a/systems/accounts/pandl_calculators/pandl_calculation.py
+++ b/systems/accounts/pandl_calculators/pandl_calculation.py
@@ -58,16 +58,10 @@ class pandlCalculation(object):
 
         as_pd_series = self.as_pd_series(**kwargs)
 
-        cum_returns = as_pd_series.cumsum()
         resample_freq = from_config_frequency_pandas_resample(frequency)
-        cum_returns_at_frequency = cum_returns.resample(resample_freq).last()
+        pd_series_at_frequency = as_pd_series.resample(resample_freq).last()
 
-        ffill_cum_returns_at_frequency = cum_returns_at_frequency.ffill()
-        returns_at_frequency = ffill_cum_returns_at_frequency.diff()
-
-        returns_at_frequency[cum_returns_at_frequency.isna()] = np.nan
-
-        return returns_at_frequency
+        return pd_series_at_frequency
 
     def as_pd_series(self, percent=False):
         if percent:


### PR DESCRIPTION
In the current form, when we first `.cumsum()` and later `.diff()`, we are losing the first value in the series - it becomes `NaN` (https://pandas.pydata.org/docs/reference/api/pandas.Series.diff.html). It seems to me that a proper resampling can be obtained with the submitted code.

I don't know what could be the repercussions of this change. Maybe there is a reason for dropping the first value that I don't understand… Please advise.