### PR TITLE
Fix for #766 resampling change

### DIFF
--- a/systems/accounts/pandl_calculators/pandl_calculation.py
+++ b/systems/accounts/pandl_calculators/pandl_calculation.py
@@ -59,7 +59,7 @@ class pandlCalculation(object):
         as_pd_series = self.as_pd_series(**kwargs)
 
         resample_freq = from_config_frequency_pandas_resample(frequency)
-        pd_series_at_frequency = as_pd_series.resample(resample_freq).last()
+        pd_series_at_frequency = as_pd_series.resample(resample_freq).sum(min_count=1)
 
         return pd_series_at_frequency
 


### PR DESCRIPTION
I didn't expect https://github.com/robcarver17/pysystemtrade/pull/766 to be merged so quickly 😄 I was thinking a bit more about why the `cumsum` was there and now I've realized that it was supposed to aggregate values from a given frequency. This PR would restore the previous behavior while fixing the problem with the first value missing.

Sorry for the confusion @robcarver17 !