### PR TITLE
Fix first value missing when adding gross and costs

### DIFF
--- a/systems/accounts/pandl_calculators/pandl_generic_costs.py
+++ b/systems/accounts/pandl_calculators/pandl_generic_costs.py
@@ -104,10 +104,6 @@ class pandlCalculationWithGenericCosts(pandlCalculation):
 
 
 def _add_gross_and_costs(gross: pd.Series, costs: pd.Series):
-    cumsum_costs = costs.cumsum()
-    cumsum_costs_aligned = cumsum_costs.reindex(gross.index, method="ffill")
-    costs_aligned = cumsum_costs_aligned.diff()
-
-    net = gross + costs_aligned
+    net = gross.add(costs, fill_value=0)
 
     return net


### PR DESCRIPTION
This is a similar problem to that in https://github.com/robcarver17/pysystemtrade/pull/766 and https://github.com/robcarver17/pysystemtrade/pull/767 where the first value is missing after `cumsum`/`diff`. When we invoke `+/add` pandas would align the series on its own.