### PR TITLE
Add path to run scripts

### DIFF
--- a/sysproduction/linux/scripts/p
+++ b/sysproduction/linux/scripts/p
@@ -1,2 +1,2 @@
 . ~/.profile
-python3 run.py $1
+python3 $SCRIPT_PATH/run.py $1


### PR DESCRIPTION
Adding the $SCRIPTS_PATH to the p file.
This way, the scrips run as indicated in the tutorials. Otherwise, you have to be in the scripts folder to run them.