### PR TITLE
Trading rule P&L report fixes

### DIFF
--- a/syscore/dateutils.py
+++ b/syscore/dateutils.py
@@ -66,7 +66,7 @@ def _get_previous_date_from_period_with_char_number(period: str,
 
     type_of_offset = period[-1]
     try:
-        number_offset = int(period[:1])
+        number_offset = int(period[:-1])
     except:
         raise Exception("Offset %s not in pattern numberLetter eg 7D for 7 days")
 

--- a/sysproduction/reporting/adhoc/trading_rule_pandl.py
+++ b/sysproduction/reporting/adhoc/trading_rule_pandl.py
@@ -52,8 +52,9 @@ def trading_rule_pandl_adhoc_report(dict_of_rule_groups: dict,
                 dict_of_rule_groups=dict_of_rule_groups,
                 data=data,
                 system = system,
-                                                      start_date=start_date,
-                                                      )
+                start_date=start_date,
+                period_label=period
+            )
 
             report_output.append(figure_object)
 
@@ -67,7 +68,8 @@ def get_figure_for_rule_group(rule_group: str,
       data: dataBlob,
       system: System,
       dict_of_rule_groups: dict,
-      start_date: datetime.datetime):
+      start_date: datetime.datetime,
+      period_label: str):
 
     rules = dict_of_rule_groups[rule_group]
     pandl_by_rule = dict([
@@ -78,9 +80,12 @@ def get_figure_for_rule_group(rule_group: str,
     concat_pd_by_rule.columns = rules
 
     pdf_output = PdfOutputWithTempFileName(data)
-    make_account_curve_plot_from_df(concat_pd_by_rule,
-                                    start_of_title="Total p&l",
-                                    start_date=start_date)
+    make_account_curve_plot_from_df(
+        concat_pd_by_rule,
+        start_of_title=f"Total Trading Rule P&L for period '{period_label}'",
+        start_date=start_date,
+        title_style={'size': 6}
+    )
 
     figure_object = pdf_output.save_chart_close_and_return_figure()
 

--- a/sysproduction/reporting/formatting.py
+++ b/sysproduction/reporting/formatting.py
@@ -33,7 +33,8 @@ def make_account_curve_plot(daily_pandl: pd.Series,
 def make_account_curve_plot_from_df(pandl_df: pd.DataFrame,
                             start_of_title: str = "",
                             start_date: datetime.datetime = arg_not_supplied,
-                            end_date: datetime.datetime = arg_not_supplied):
+                            end_date: datetime.datetime = arg_not_supplied,
+                            title_style: dict = None):
 
     curve_to_plot = pandl_df.resample("1B").sum()
     if start_date is not arg_not_supplied:
@@ -56,7 +57,7 @@ def make_account_curve_plot_from_df(pandl_df: pd.DataFrame,
                   str(ann_std.round(3).to_dict()),
                   str(ann_sr.round(2).to_dict()))
     curve_to_plot.cumsum().plot()
-    title(full_title)
+    title(full_title, fontdict=title_style)
 
 
 


### PR DESCRIPTION
- fixes a bug that caused period strings to only consider the first digit, eg '10Y' would produce a one year period
- add the period to the plot title
- set the plot title font in the Trading Rule P&L report to be much smaller, improving readability