### PR TITLE
Remove check for missing_contract...

### DIFF
--- a/sysproduction/data/contracts.py
+++ b/sysproduction/data/contracts.py
@@ -380,9 +380,6 @@ def label_up_contracts_with_date_list(
 
     contract_names = []
     for contract in contract_date_list:
-        if contract is missing_contract:
-            contract_names.append("")
-            continue
 
         if contract == price_contract_date:
             suffix = PRICE_SUFFIX


### PR DESCRIPTION
...in label_up_contracts_with_date_list.

I could not find a way for this to ever be missing_contract, even before I started making these changes.

In any case, if I'm wrong and there are situations where an exception will be raised, it should be handled upstream, not in this method.