### PR TITLE
Refactor strategyRunner

### DIFF
--- a/syscontrol/list_running_pids.py
+++ b/syscontrol/list_running_pids.py
@@ -3,7 +3,6 @@ import subprocess
 
 from syscore.exceptions import missingData
 from sysdata.config.production_config import get_production_config
-from syscore.objects import missing_data
 
 ## IF THIS FILE IS MOVED, NEED TO UPDATE THE NEXT LINE
 ## WARNING ONLY WORKS ON LINUX??

--- a/syscontrol/strategy_tools.py
+++ b/syscontrol/strategy_tools.py
@@ -15,7 +15,7 @@ class strategyRunner:
         self._process_name = process_name
 
         self._strategy_method = get_strategy_method(
-            self.data, self.strategy_name, self.process_name, self.function_name
+            self.data, self._strategy_name, self._process_name, self._function_name
         )
 
     @property
@@ -33,10 +33,6 @@ class strategyRunner:
     @property
     def strategy_method(self):
         return self._strategy_method
-
-    @strategy_method.setter
-    def strategy_method(self, new_object):
-        self._strategy_method = new_object
 
     def run_strategy_method(self):
         method = self.strategy_method

--- a/syscontrol/strategy_tools.py
+++ b/syscontrol/strategy_tools.py
@@ -1,5 +1,5 @@
 from copy import copy
-from syscore.objects import resolve_function, missing_data
+from syscore.objects import resolve_function
 from sysdata.data_blob import dataBlob
 from sysproduction.data.control_process import get_strategy_class_object_config
 
@@ -10,10 +10,13 @@ class strategyRunner:
         self, data: dataBlob, strategy_name: str, process_name: str, function_name: str
     ):
         self.data = data
-        self._object_store = missing_data
         self._strategy_name = strategy_name
         self._function_name = function_name
         self._process_name = process_name
+
+        self._strategy_method = get_strategy_method(
+            self.data, self.strategy_name, self.process_name, self.function_name
+        )
 
     @property
     def strategy_name(self):
@@ -28,27 +31,17 @@ class strategyRunner:
         return self._process_name
 
     @property
-    def object_store(self):
-        return self._object_store
+    def strategy_method(self):
+        return self._strategy_method
 
-    @object_store.setter
-    def object_store(self, new_object):
-        self._object_store = new_object
+    @strategy_method.setter
+    def strategy_method(self, new_object):
+        self._strategy_method = new_object
 
     def run_strategy_method(self):
-        method = self.get_strategy_method()
+        method = self.strategy_method
         # no arguments. no return. no explanations
         method()
-
-    def get_strategy_method(self):
-        method = self._object_store
-        if method is missing_data:
-            method = get_strategy_method(
-                self.data, self.strategy_name, self.process_name, self.function_name
-            )
-            self.object_store = method
-
-        return method
 
 
 def get_strategy_method(


### PR DESCRIPTION
This might be more controversial than my usual pull requests...

- Rename _object_store attribute to _strategy_method (confusing to have 2 names for same thing)
- Initialize _strategy_method when object is initialized (avoid need to check for missing_data...my mission in life)
- Remove unused setter method

I didn't see any purpose in allowing a strategyRunner to be created without also initializing the _object_store / _strategy_method at the same time.

Let me know if you had a reason for doing it that way.

