### PR TITLE
Raise missingData when getting objects from cache

### DIFF
--- a/syscore/cache.py
+++ b/syscore/cache.py
@@ -6,7 +6,6 @@ There is the caching in the base system, but that's special uses decorators etc
 Here's a more general one
 """
 
-from syscore.objects import missing_data
 
 class Cache(object):
     def __init__(self, parent_object):
@@ -16,8 +15,9 @@ class Cache(object):
     def get(self, function_instance, *args, **kwargs):
         function_name = function_instance.__name__
         key = _get_key(function_name, args, kwargs)
-        value_from_store = self._get_from_store(key)
-        if value_from_store is missing_data:
+        try:
+            value_from_store = self._get_from_store(key)
+        except KeyError:
             value_from_store = self._calculate_and_store(key, function_instance, *args, **kwargs)
 
         return value_from_store
@@ -32,7 +32,7 @@ class Cache(object):
         self.store[key] = value
 
     def _get_from_store(self, key: str):
-        return self.store.get(key, missing_data)
+        return self.store.get(key)
 
     @property
     def store(self) -> dict:

--- a/syscore/cache.py
+++ b/syscore/cache.py
@@ -6,6 +6,7 @@ There is the caching in the base system, but that's special uses decorators etc
 Here's a more general one
 """
 from syscore.exceptions import missingData
+from syscore.objects import missing_data
 
 
 class Cache(object):
@@ -33,9 +34,8 @@ class Cache(object):
         self.store[key] = value
 
     def _get_from_store(self, key: str):
-        try:
-            return self.store.get(key)
-        except KeyError:
+        value = self.store.get(key, missing_data)
+        if value is missing_data:
             raise missingData("Missing cache element %s" % key)
 
     @property

--- a/syscore/cache.py
+++ b/syscore/cache.py
@@ -5,6 +5,7 @@ There is the caching in the base system, but that's special uses decorators etc
 
 Here's a more general one
 """
+from syscore.exceptions import missingData
 
 
 class Cache(object):
@@ -17,7 +18,7 @@ class Cache(object):
         key = _get_key(function_name, args, kwargs)
         try:
             value_from_store = self._get_from_store(key)
-        except KeyError:
+        except missingData:
             value_from_store = self._calculate_and_store(key, function_instance, *args, **kwargs)
 
         return value_from_store
@@ -32,7 +33,10 @@ class Cache(object):
         self.store[key] = value
 
     def _get_from_store(self, key: str):
-        return self.store.get(key)
+        try:
+            return self.store.get(key)
+        except KeyError:
+            raise missingData("Missing cache element %s" % key)
 
     @property
     def store(self) -> dict:

--- a/syscore/cache.py
+++ b/syscore/cache.py
@@ -37,6 +37,7 @@ class Cache(object):
         value = self.store.get(key, missing_data)
         if value is missing_data:
             raise missingData("Missing cache element %s" % key)
+        return value
 
     @property
     def store(self) -> dict:


### PR DESCRIPTION
A use of the missing_data object that I don't object to! :smile: 

I would just confine it to the method where it is needed by immediately translating it to an exception.  Any caller not prepared to deal with a missing cache object will be rudely notified of their error, rather than blithely passing a missing_data object up the stack.

Not a big deal here, since it's only called from one place (internally).  But I'm a stickler for principle.

