### PR TITLE
Black setup and config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,10 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# pysystemtrade contributing guide
+
+
+## unit tests
+This project has a few unit tests. They get run automatically when any PR is 
+submitted. You'll see the result of the run in the PR page. To run the tests
+yourself locally, before submitting, you'll need `pytest` installed. Then run:
+```
+pytest
+```
+
+to run an individual unit test, pass the module file name and path
+```
+pytest sysdata/tests/test_config.py
+```
+
+To run all the tests except one module, use the `--ignore` flag
+```
+pytest --ignore=sysinit/futures/tests/test_sysinit_futures.py
+```
+
+Some tests are marked as `@pytest.mark.slow` because they take a long time. These
+run automatically every evening. If you want to run them locally, pass
+the `--runslow` flag
+```
+pytest --runslow
+```
+
+
+## lint
+
+This project keeps its code pretty with 
+[Black](https://black.readthedocs.io/en/stable/). Black gets automatically run 
+over any PRs, and the PR won't be merged if it fails. To clean your code
+submission manually you'll need Black installed, instructions 
+[here](https://black.readthedocs.io/en/stable/getting_started.html). Then
+run:
+```
+black path/to/module.py
+```
+
+Or, get your IDE or editor to automatically re-format files as you save. Configuration
+instructions [here](https://black.readthedocs.io/en/stable/integrations/editors.html)
+
+Or, configure your local git install to automatically check and fix your code
+as you commit. Configuration instructions 
+[here](https://black.readthedocs.io/en/stable/integrations/source_version_control.html)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.pytest.ini_options]
+norecursedirs = "examples"
+addopts = "--ignore=systems/provided/moretradingrules/temp.py"
+
+[tool.black]
+line-length = 88
+target-version = ['py38']

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-norecursedirs = examples
-addopts = --ignore=systems/provided/moretradingrules/temp.py


### PR DESCRIPTION
This change includes:
- config for a new GitHub action named 'Lint' that will run Black (in check mode) over every push or pull request
- config for a git hook that will run Black on commit for developers that have pre-commit configured in their local environment
- a minimal pyproject.toml file that configures Black for developers who run it manually or via their IDE. It also configures pytest, replacing the pytest.ini file
- a new CONTRIBUTION.md file - a simple guide for developers on using pytest and Black in the project

Checks will fail for this PR until the whole codebase has been Blacked. Should not be merged until then