### PR TITLE
Removed some uses of missing_data

### DIFF
--- a/sysdata/config/instruments.py
+++ b/sysdata/config/instruments.py
@@ -1,5 +1,4 @@
-from syscore.objects import missing_data, arg_not_supplied
-from sysdata.config.configdata import default_config, Config
+from sysdata.config.configdata import Config
 
 
 def get_list_of_bad_instruments_in_config(config: Config) -> list:

--- a/sysdata/config/instruments.py
+++ b/sysdata/config/instruments.py
@@ -41,12 +41,8 @@ def generate_matching_duplicate_dict(config: Config):
     """
 
     duplicate_instruments_config = config.get_element("duplicate_instruments")
-    exclude_dict = duplicate_instruments_config.get("exclude", missing_data)
-    include_dict = duplicate_instruments_config.get("include", missing_data)
-    if exclude_dict is missing_data or include_dict is missing_data:
-        raise Exception(
-            "Need 'duplicate_instruments': exclude_dict and include_dict in config"
-        )
+    exclude_dict = duplicate_instruments_config.get("exclude", {})
+    include_dict = duplicate_instruments_config.get("include", {})
 
     joint_keys = list(set(list(exclude_dict.keys()) + list(include_dict.keys())))
 
@@ -96,9 +92,7 @@ def get_duplicate_list_of_instruments_to_remove_from_config(config: Config) -> l
         "duplicate_instruments", {}
     )
 
-    exclude_dict = duplicate_instruments_config.get("exclude", missing_data)
-    if exclude_dict is missing_data:
-        return []
+    exclude_dict = duplicate_instruments_config.get("exclude", {})
     list_of_duplicates = list(exclude_dict.values())
 
     ## do this because can have multiple duplicates


### PR DESCRIPTION
Minor change to behavior when getting include/exclude instrument lists.

Used to raise an exception if the include or exclude entry was not found.  Now will just return an empty dictionary and continue.

Seems OK to me, and saves a few lines of code, but let me know if you think it is important to enforce that the include & exclude entries are present.



