### PR TITLE
don't create excessive broker contract and instrument data instances

### DIFF
--- a/sysbrokers/IB/ib_Fx_prices_data.py
+++ b/sysbrokers/IB/ib_Fx_prices_data.py
@@ -4,7 +4,7 @@ import pandas as pd
 from sysbrokers.IB.client.ib_fx_client import ibFxClient
 from sysbrokers.broker_fx_prices_data import brokerFxPricesData
 from syscore.exceptions import missingData
-
+from sysdata.data_blob import dataBlob
 from sysobjects.spot_fx_prices import fxPrices
 from syslogdiag.log_to_screen import logtoscreen
 from syscore.fileutils import resolve_path_and_filename_for_package
@@ -18,9 +18,12 @@ ibFXConfig = namedtuple("ibFXConfig", ["ccy1", "ccy2", "invert"])
 
 
 class ibFxPricesData(brokerFxPricesData):
-    def __init__(self, ibconnection, log=logtoscreen("ibFxPricesData")):
-        self._ibconnection = ibconnection
+    def __init__(
+        self, ibconnection, data_blob: dataBlob, log=logtoscreen("ibFxPricesData")
+    ):
         super().__init__(log=log)
+        self._ibconnection = ibconnection
+        self._dataBlob = data_blob
 
     def __repr__(self):
         return "IB FX price data"

--- a/sysbrokers/IB/ib_capital_data.py
+++ b/sysbrokers/IB/ib_capital_data.py
@@ -1,7 +1,7 @@
 from sysbrokers.IB.ib_connection import connectionIB
 from sysbrokers.IB.client.ib_accounting_client import ibAccountingClient
 from sysbrokers.broker_capital_data import brokerCapitalData
-
+from sysdata.data_blob import dataBlob
 from syscore.constants import arg_not_supplied
 
 from sysobjects.spot_fx_prices import listOfCurrencyValues
@@ -12,10 +12,14 @@ from syslogdiag.log_to_screen import logtoscreen
 
 class ibCapitalData(brokerCapitalData):
     def __init__(
-        self, ibconnection: connectionIB, log: logger = logtoscreen("ibCapitalData")
+        self,
+        ibconnection: connectionIB,
+        data_blob: dataBlob,
+        log: logger = logtoscreen("ibCapitalData"),
     ):
         super().__init__(log=log)
         self._ibconnection = ibconnection
+        self._dataBlob = data_blob
 
     @property
     def ibconnection(self) -> connectionIB:

--- a/sysbrokers/IB/ib_contract_position_data.py
+++ b/sysbrokers/IB/ib_contract_position_data.py
@@ -1,7 +1,7 @@
 from syscore.exceptions import missingContract
 from syslogdiag.log_to_screen import logtoscreen
 from sysbrokers.IB.ib_futures_contracts_data import ibFuturesContractData
-
+from sysdata.data_blob import dataBlob
 from sysbrokers.IB.client.ib_positions_client import ibPositionsClient
 from sysbrokers.IB.ib_instruments_data import ibFuturesInstrumentData
 from sysbrokers.IB.ib_connection import connectionIB
@@ -15,10 +15,18 @@ from sysobjects.contracts import futuresContract
 
 class ibContractPositionData(brokerContractPositionData):
     def __init__(
-        self, ibconnection: connectionIB, log=logtoscreen("ibContractPositionData")
+        self,
+        ibconnection: connectionIB,
+        data_blob: dataBlob,
+        log=logtoscreen("ibContractPositionData"),
     ):
-        self._ibconnection = ibconnection
         super().__init__(log=log)
+        self._ibconnection = ibconnection
+        self._dataBlob = data_blob
+
+    @property
+    def data(self):
+        return self._dataBlob
 
     @property
     def ibconnection(self) -> connectionIB:
@@ -39,11 +47,11 @@ class ibContractPositionData(brokerContractPositionData):
 
     @property
     def futures_contract_data(self) -> ibFuturesContractData:
-        return ibFuturesContractData(self.ibconnection, log=self.log)
+        return self.data.broker_futures_contract
 
     @property
     def futures_instrument_data(self) -> ibFuturesInstrumentData:
-        return ibFuturesInstrumentData(self.ibconnection, log=self.log)
+        return self.data.broker_futures_instrument
 
     def get_all_current_positions_as_list_with_contract_objects(
         self, account_id=arg_not_supplied

--- a/sysbrokers/IB/ib_futures_contract_price_data.py
+++ b/sysbrokers/IB/ib_futures_contract_price_data.py
@@ -1,6 +1,6 @@
 from syscore.dateutils import Frequency, DAILY_PRICE_FREQ, MIXED_FREQ
 from syscore.exceptions import missingContract, missingData
-
+from sysdata.data_blob import dataBlob
 from sysbrokers.IB.ib_futures_contracts_data import ibFuturesContractData
 from sysbrokers.IB.ib_instruments_data import ibFuturesInstrumentData
 from sysbrokers.IB.ib_translate_broker_order_objects import sign_from_BS, ibBrokerOrder
@@ -74,13 +74,21 @@ class ibFuturesContractPriceData(brokerFuturesContractPriceData):
     """
 
     def __init__(
-        self, ibconnection: connectionIB, log=logtoscreen("ibFuturesContractPriceData")
+        self,
+        ibconnection: connectionIB,
+        data_blob: dataBlob,
+        log=logtoscreen("ibFuturesContractPriceData"),
     ):
-        self._ibconnection = ibconnection
         super().__init__(log=log)
+        self._ibconnection = ibconnection
+        self._dataBlob = data_blob
 
     def __repr__(self):
         return "IB Futures per contract price data %s" % str(self.ib_client)
+
+    @property
+    def data(self):
+        return self._dataBlob
 
     @property
     def ibconnection(self) -> connectionIB:
@@ -98,11 +106,11 @@ class ibFuturesContractPriceData(brokerFuturesContractPriceData):
 
     @property
     def futures_contract_data(self) -> ibFuturesContractData:
-        return ibFuturesContractData(self.ibconnection, log=self.log)
+        return self.data.broker_futures_contract
 
     @property
     def futures_instrument_data(self) -> ibFuturesInstrumentData:
-        return ibFuturesInstrumentData(self.ibconnection, log=self.log)
+        return self.data.broker_futures_instrument
 
     def has_merged_price_data_for_contract(
         self, futures_contract: futuresContract

--- a/sysbrokers/IB/ib_futures_contracts_data.py
+++ b/sysbrokers/IB/ib_futures_contracts_data.py
@@ -8,7 +8,7 @@ from sysbrokers.broker_futures_contract_data import brokerFuturesContractData
 
 from syscore.constants import missing_instrument
 from syscore.exceptions import missingContract, missingData
-
+from sysdata.data_blob import dataBlob
 from sysobjects.contract_dates_and_expiries import expiryDate, listOfContractDateStr
 from sysobjects.contracts import futuresContract
 from sysobjects.production.trading_hours.trading_hours import listOfTradingHours
@@ -26,13 +26,21 @@ class ibFuturesContractData(brokerFuturesContractData):
     """
 
     def __init__(
-        self, ibconnection: connectionIB, log=logtoscreen("ibFuturesContractData")
+        self,
+        ibconnection: connectionIB,
+        data_blob: dataBlob,
+        log=logtoscreen("ibFuturesContractData"),
     ):
         super().__init__(log=log)
         self._ibconnection = ibconnection
+        self._dataBlob = data_blob
 
     def __repr__(self):
         return "IB Futures per contract data %s" % str(self.ib_client)
+
+    @property
+    def data(self):
+        return self._dataBlob
 
     @property
     def ibconnection(self) -> connectionIB:
@@ -50,7 +58,7 @@ class ibFuturesContractData(brokerFuturesContractData):
 
     @property
     def ib_futures_instrument_data(self) -> ibFuturesInstrumentData:
-        return ibFuturesInstrumentData(self.ibconnection, log=self.log)
+        return self.data.broker_futures_instrument
 
     def get_list_of_contract_dates_for_instrument_code(
         self, instrument_code: str

--- a/sysbrokers/IB/ib_fx_handling.py
+++ b/sysbrokers/IB/ib_fx_handling.py
@@ -5,12 +5,19 @@ from sysbrokers.IB.client.ib_fx_client import ibFxClient
 from sysbrokers.IB.ib_connection import connectionIB
 from sysbrokers.IB.ib_translate_broker_order_objects import tradeWithContract
 from sysbrokers.broker_fx_handling import brokerFxHandlingData
+from sysdata.data_blob import dataBlob
 
 
 class ibFxHandlingData(brokerFxHandlingData):
-    def __init__(self, ibconnection: connectionIB, log=logtoscreen("ibFXHandlingData")):
-        self._ibconnection = ibconnection
+    def __init__(
+        self,
+        ibconnection: connectionIB,
+        data_blob: dataBlob,
+        log=logtoscreen("ibFXHandlingData"),
+    ):
         super().__init__(log=log)
+        self._ibconnection = ibconnection
+        self._dataBlob = data_blob
 
     def __repr__(self):
         return "IB FX handling data %s" % str(self.ib_client)

--- a/sysbrokers/IB/ib_instruments_data.py
+++ b/sysbrokers/IB/ib_instruments_data.py
@@ -7,7 +7,7 @@ from sysbrokers.IB.ib_instruments import (
 )
 from sysbrokers.IB.ib_connection import connectionIB
 from sysbrokers.broker_instrument_data import brokerFuturesInstrumentData
-
+from sysdata.data_blob import dataBlob
 from syscore.fileutils import resolve_path_and_filename_for_package
 from syscore.genutils import return_another_value_if_nan
 from syscore.constants import missing_instrument, missing_file
@@ -40,10 +40,14 @@ class ibFuturesInstrumentData(brokerFuturesInstrumentData):
     """
 
     def __init__(
-        self, ibconnection: connectionIB, log=logtoscreen("ibFuturesContractData")
+        self,
+        ibconnection: connectionIB,
+        data_blob: dataBlob,
+        log=logtoscreen("ibFuturesContractData"),
     ):
         super().__init__(log=log)
         self._ibconnection = ibconnection
+        self._dataBlob = data_blob
 
     def __repr__(self):
         return "IB Futures per contract data %s" % str(self.ibconnection)

--- a/sysbrokers/IB/ib_orders.py
+++ b/sysbrokers/IB/ib_orders.py
@@ -17,7 +17,7 @@ from sysbrokers.IB.ib_translate_broker_order_objects import (
 )
 from sysbrokers.IB.client.ib_orders_client import ibOrdersClient
 from sysbrokers.broker_execution_stack import brokerExecutionStackData
-
+from sysdata.data_blob import dataBlob
 from syscore.constants import arg_not_supplied, success, failure
 from syscore.exceptions import orderCannotBeModified
 from sysexecution.orders.named_order_objects import missing_order
@@ -93,13 +93,21 @@ class ibOrderWithControls(orderWithControls):
 
 class ibExecutionStackData(brokerExecutionStackData):
     def __init__(
-        self, ibconnection: connectionIB, log=logtoscreen("ibExecutionStackData")
+        self,
+        ibconnection: connectionIB,
+        data_blob: dataBlob,
+        log=logtoscreen("ibExecutionStackData"),
     ):
         super().__init__(log=log)
         self._ibconnection = ibconnection
+        self._dataBlob = data_blob
 
     def __repr__(self):
         return "IB orders %s" % str(self.ib_client)
+
+    @property
+    def data(self):
+        return self._dataBlob
 
     @property
     def ibconnection(self) -> connectionIB:
@@ -131,11 +139,11 @@ class ibExecutionStackData(brokerExecutionStackData):
 
     @property
     def futures_contract_data(self) -> ibFuturesContractData:
-        return ibFuturesContractData(self.ibconnection)
+        return self.data.broker_futures_contract
 
     @property
     def futures_instrument_data(self) -> ibFuturesInstrumentData:
-        return ibFuturesInstrumentData(self.ibconnection)
+        return self.data.broker_futures_instrument
 
     def get_list_of_broker_orders_with_account_id(
         self, account_id: str = arg_not_supplied

--- a/sysbrokers/IB/ib_static_data.py
+++ b/sysbrokers/IB/ib_static_data.py
@@ -2,12 +2,19 @@ from syslogdiag.log_to_screen import logtoscreen
 from sysbrokers.IB.client.ib_client import ibClient
 from sysbrokers.IB.ib_connection import connectionIB
 from sysbrokers.broker_static_data import brokerStaticData
+from sysdata.data_blob import dataBlob
 
 
 class ibStaticData(brokerStaticData):
-    def __init__(self, ibconnection: connectionIB, log=logtoscreen("ibStaticData")):
-        self._ibconnection = ibconnection
+    def __init__(
+        self,
+        ibconnection: connectionIB,
+        data_blob: dataBlob,
+        log=logtoscreen("ibStaticData"),
+    ):
         super().__init__(log=log)
+        self._ibconnection = ibconnection
+        self._dataBlob = data_blob
 
     def __repr__(self):
         return "IB static data %s" % str(self.ib_client)

--- a/sysdata/data_blob.py
+++ b/sysdata/data_blob.py
@@ -124,11 +124,11 @@ class dataBlob(object):
     def _add_ib_class(self, class_object):
         log = self._get_specific_logger(class_object)
         try:
-            resolved_instance = class_object(self.ib_conn, log=log)
+            resolved_instance = class_object(self.ib_conn, self, log=log)
         except Exception as e:
             class_name = get_class_name(class_object)
             msg = (
-                "Error %s couldn't evaluate %s(self.ib_conn, log = self.log.setup(component = %s)) This might be because (a) IB gateway not running, or (b) import is missing\
+                "Error %s couldn't evaluate %s(self.ib_conn, self, log = self.log.setup(component = %s)) This might be because (a) IB gateway not running, or (b) import is missing\
                          or (c) arguments don't follow pattern"
                 % (str(e), class_name, class_name)
             )


### PR DESCRIPTION
Some of the broker data classes (`ib*Data`) were creating their own instances of the contract data and instrument data objects, because they had no easy way to access the ones managed by `dataBlob`. And they would create a new one *for each method call*. I added some basic logging to the `__init__()` methods of `ibFuturesInstrumentData` and `ibFuturesContractData`. The object creation counts are shown below. I had the debugging statements running on 23 Jan, the values for 20 Jan are there as a baseline 

```
$ grep -o '%%% ibFuturesInstrumentData' run_stack_handler_20230123.arch | wc -l
4942996
$ grep -o '%%% ibFuturesContractData' run_stack_handler_20230123.arch | wc -l
366
$ grep -o '%%% ibFuturesInstrumentData' run_stack_handler_20230120.arch | wc -l
0
$ grep -o '%%% ibFuturesContractData' run_stack_handler_20230120.arch | wc -l
28

$ grep -o '%%% ibFuturesInstrumentData' run_daily_price_updates_20230123.arch | wc -l
984
$ grep -o '%%% ibFuturesInstrumentData' run_daily_price_updates_20230120.arch | wc -l
0
$ grep -o '%%% ibFuturesContractData' run_daily_price_updates_20230123.arch | wc -l
597
$ grep -o '%%% ibFuturesContractData' run_daily_price_updates_20230120.arch | wc -l
0
```

Nearly 5 million instances of `ibFuturesInstrumentData` were created during running of the stack handler. And that's with only 70 odd instruments. This change fixes that problem - dataBlob passes itself to the `ib*Data` instances on creation