### PR TITLE
Adding Australian trading hours to IB config

### DIFF
--- a/sysbrokers/IB/ib_config_trading_hours.yaml
+++ b/sysbrokers/IB/ib_config_trading_hours.yaml
@@ -72,3 +72,6 @@ HongKong:
 Hongkong:
   - '01:00'
   - '06:00'
+Australia/NSW:
+  - '22:00'
+  - '03:00'

--- a/sysbrokers/IB/ib_trading_hours.py
+++ b/sysbrokers/IB/ib_trading_hours.py
@@ -131,6 +131,7 @@ def get_time_difference(time_zone_id: str) -> int:
         "US/Central": 6,
         "GB-Eire": 0,
         "Hongkong": -7,
+        "Australia/NSW": -10,
         "": 0,
     }
     GMT_offset_hours = get_GMT_offset_hours()


### PR DESCRIPTION
Question: why are Hong Kong and Japan listed as -7 and -8, rather than -8 and -9 (which I would expect as they are UTC+8 and UTC+9)? 
I followed this strange convention and listed Australia/NSW as -10 (as it is UTC+11).
In case this is a mistake, then perhaps all three should be changed to -8, -9 and -11?