### PR TITLE
Adding portfolio / asset class betas to risk report

### DIFF
--- a/sysproduction/reporting/api.py
+++ b/sysproduction/reporting/api.py
@@ -677,7 +677,7 @@ class reportingApi(object):
         beta_load_by_asset_class = beta_load_by_asset_class.round(2)
         beta_load_by_asset_class = beta_load_by_asset_class.sort_values()
         beta_load_by_asset_class_table = table(
-            "Beta loadings by asset class", beta_load_by_asset_class
+            "Beta loadings of asset class positions on asset class", beta_load_by_asset_class
         )
 
         return beta_load_by_asset_class_table
@@ -690,7 +690,7 @@ class reportingApi(object):
         portfolio_beta_load_by_asset_class = portfolio_beta_load_by_asset_class.round(2)
         portfolio_beta_load_by_asset_class = portfolio_beta_load_by_asset_class.sort_values()
         portfolio_beta_load_by_asset_class_table = table(
-            "Portfolio beta loadings on each asset class", portfolio_beta_load_by_asset_class
+            "Beta loadings of full portfolio positions on asset class", portfolio_beta_load_by_asset_class
         )
 
         return portfolio_beta_load_by_asset_class_table

--- a/sysproduction/reporting/api.py
+++ b/sysproduction/reporting/api.py
@@ -682,6 +682,19 @@ class reportingApi(object):
 
         return beta_load_by_asset_class_table
 
+    def table_of_portfolio_beta_loadings_by_asset_class(self):
+        portfolio_risk_object = self.portfolio_risks
+        portfolio_beta_load_by_asset_class = (
+            portfolio_risk_object.get_portfolio_beta_loadings_by_asset_class()
+        )
+        portfolio_beta_load_by_asset_class = portfolio_beta_load_by_asset_class.round(2)
+        portfolio_beta_load_by_asset_class = portfolio_beta_load_by_asset_class.sort_values()
+        portfolio_beta_load_by_asset_class_table = table(
+            "Portfolio beta loadings on each asset class", portfolio_beta_load_by_asset_class
+        )
+
+        return portfolio_beta_load_by_asset_class_table
+
     @property
     def portfolio_risks(self) -> portfolioRisks:
         return self.cache.get(self._portfolio_risks)

--- a/sysproduction/reporting/risk_report.py
+++ b/sysproduction/reporting/risk_report.py
@@ -19,6 +19,7 @@ def risk_report(data: dataBlob = arg_not_supplied):
         "table_of_strategy_risk",
         "table_of_risk_by_asset_class",
         "table_of_beta_loadings_by_asset_class",
+        "table_of_portfolio_beta_loadings_by_asset_class",
         "table_of_instrument_risk",
         "body_text_abs_total_all_risk_perc_capital",
         "body_text_abs_total_all_risk_annualised",


### PR DESCRIPTION
This adds a calculation of the beta of y = (historical portfolio returns given that positions were fixed to the current positions) on x = (historical long only returns of asset class, computed by taking equal weight of the instruments in that asset class that are currently in the strategy config).
It also gives a different description of the existing beta computation to better distinguish it from the new one.

Useful further improvements that are not yet implement would be:
- adding a measure of how much of the variation in portfolio returns each asset class explains - something like a correlation
- perhaps using not just the asset class members that are in the strategy config, but all members of that asset class that we have data for?