### PR TITLE
remove .position

### DIFF
--- a/sysproduction/strategy_code/report_system_classic.py
+++ b/sysproduction/strategy_code/report_system_classic.py
@@ -468,7 +468,7 @@ def get_position_for_instrument_code_at_timestamp(data_backtest, data, instrumen
 
     if len(positions_before_cutoff) == 0:
         return np.nan
-    final_position = positions_before_cutoff.iloc[-1].position
+    final_position = positions_before_cutoff.iloc[-1]
 
     return final_position
 


### PR DESCRIPTION
returned dataframe doesn't seem to have position column, throwing an error when running strategy report. iloc[-1] should be sufficient.