### PR TITLE
Fix error handling when contract not found

### DIFF
--- a/sysbrokers/IB/client/ib_client.py
+++ b/sysbrokers/IB/client/ib_client.py
@@ -195,16 +195,10 @@ class ibClient(object):
         ib_contract_pattern: ibContract,
     ) -> IBInstrumentIdentity:
 
-        contract_details = self.get_contract_details(
-            ib_contract_pattern=ib_contract_pattern,
-            allow_expired=False,
-            allow_multiple_contracts=False,
-        )
-
         return IBInstrumentIdentity(
-            ib_code=str(contract_details.contract.symbol),
-            ib_multiplier=float(contract_details.contract.multiplier),
-            ib_exchange=str(contract_details.contract.exchange),
+            ib_code=ib_contract_pattern.symbol,
+            ib_multiplier=float(ib_contract_pattern.multiplier),
+            ib_exchange=ib_contract_pattern.exchange,
         )
 
     def get_contract_details(


### PR DESCRIPTION
You don't have to merge this, but this is working for me.

Problem: calling reqContractDetails while handling an error from reqContractDetails

Solution: you don't need to call reqContractDetails during the error handling process (or anytime you have an ibContract object). The ibContract will have everything needed for IBInstrumentIdentity.  

Two possibilities: 

1) the ibContract object came from IB, in which case all relevant attributes are populated

2) the ibContract object came from pysystemtrade, in which case the necessary attributes are populated because we got them from ib_config_futures.csv