### PR TITLE
Fix minor bug in path resolution

### DIFF
--- a/syscore/fileutils.py
+++ b/syscore/fileutils.py
@@ -287,9 +287,13 @@ def get_relative_pathname_from_list(path_as_list: List[str]) -> str:
     paths_or_files = path_as_list[1:]
 
     if len(paths_or_files) == 0:
-        directory_name_of_package = os.path.dirname(
-            import_module(package_name).__file__
-        )
+        base_dir = os.getenv("PYSYS_CODE")
+        if base_dir is not None:
+            directory_name_of_package = os.path.join(base_dir, package_name)
+        else:
+            directory_name_of_package = os.path.dirname(
+                import_module(package_name).__file__
+            )
         return directory_name_of_package
 
     last_item_in_list = path_as_list.pop()


### PR DESCRIPTION
I'm definitely open to other solutions here...or maybe you won't even think this is worth fixing...

Problem: sysproduction scripts can't resolve the "data" package when run from the command line (e.g., `python3 $PYSYS_CODE/sysproduction/run_systems.py`). The sysproduction.data package is imported instead of the top-level data package, resulting in file not found errors looking for the instrument config.

Solution: if the PYSYS_CODE environment variable is defined, use that to get the path instead of trying to do an import.  Retain the import method so the environment variable is not a hard requirement.

Note: The production run scripts work because they use run.py, in the linux/scripts sub-folder - they don't run the sysproduction scripts directly from the command line.

Alternative solutions would be to rename the sysproduction.data folder, or move the scripts in sysproduction to a sub-folder.


