### PR TITLE
Revert change in PR #1095

### DIFF
--- a/syscore/fileutils.py
+++ b/syscore/fileutils.py
@@ -287,13 +287,9 @@ def get_relative_pathname_from_list(path_as_list: List[str]) -> str:
     paths_or_files = path_as_list[1:]
 
     if len(paths_or_files) == 0:
-        base_dir = os.getenv("PYSYS_CODE")
-        if base_dir is not None:
-            directory_name_of_package = os.path.join(base_dir, package_name)
-        else:
-            directory_name_of_package = os.path.dirname(
-                import_module(package_name).__file__
-            )
+        directory_name_of_package = os.path.dirname(
+            import_module(package_name).__file__
+        )
         return directory_name_of_package
 
     last_item_in_list = path_as_list.pop()


### PR DESCRIPTION
As I've mentioned in comments elsewhere, the change in #1095 could change where config files are read from when PYSYS_CODE is defined.

Depending on how pysystemtrade was installed, and how people are managing changes to their config files