### PR TITLE
changing spelling of Asia to all upper case

### DIFF
--- a/syscontrol/control_config.yaml
+++ b/syscontrol/control_config.yaml
@@ -27,7 +27,7 @@ process_configuration_stop_time:
 #  run_daily_prices_updates:
 #    update_historical_prices: # everything in this block is passed as **kwargs to this method
 #      download_by_zone:
-#        Asia: '07:00'
+#        ASIA: '07:00'
 #        EMEA: '18:00'
 #        US: '20:00'
 #    _methods_on_completion: # and this block is passed to all methods that run on completion only


### PR DESCRIPTION
The sample for download start time arguments for different zones for updating daily prices have Asia spelled wrong. This should be all in upper case.