### PR TITLE
Make interactive_update_roll_status faster

### DIFF
--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -30,6 +30,7 @@ from sysobjects.production.roll_state import (
     no_roll_state,
     roll_close_state,
 )
+from sysproduction.reporting.api import reportingApi
 
 from sysproduction.reporting.report_configs import roll_report_config
 from sysproduction.reporting.reporting_functions import run_report_with_data_blob
@@ -114,49 +115,49 @@ class RollDataWithStateReporting(object):
         print("")
 
 
-def update_roll_status_manual_cycle(data: dataBlob):
+def update_roll_status_manual_cycle(api: reportingApi):
 
     do_another = True
     while do_another:
         instrument_code = get_valid_instrument_code_from_user(
-            data=data, allow_exit=True, exit_code=EXIT_CODE
+            data=api.data, allow_exit=True, exit_code=EXIT_CODE
         )
         if instrument_code is EXIT_CODE:
             # belt and braces
             do_another = False
         else:
-            manually_report_and_update_roll_state_for_code(data, instrument_code)
+            manually_report_and_update_roll_state_for_code(api, instrument_code)
 
     return success
 
 
-def update_roll_status_auto_cycle_manual_decide(data: dataBlob):
+def update_roll_status_auto_cycle_manual_decide(api: reportingApi):
     days_ahead = get_days_ahead_to_consider_when_auto_cycling()
-    instrument_list = get_list_of_instruments_to_auto_cycle(data, days_ahead=days_ahead)
+    instrument_list = get_list_of_instruments_to_auto_cycle(api.data, days_ahead=days_ahead)
     for instrument_code in instrument_list:
         manually_report_and_update_roll_state_for_code(
-            data=data, instrument_code=instrument_code
+            api=api, instrument_code=instrument_code
         )
 
     return success
 
 
-def update_roll_status_auto_cycle_manual_confirm(data: dataBlob):
+def update_roll_status_auto_cycle_manual_confirm(api: reportingApi):
     days_ahead = get_days_ahead_to_consider_when_auto_cycling()
     auto_parameters = get_auto_roll_parameters()
-    instrument_list = get_list_of_instruments_to_auto_cycle(data, days_ahead=days_ahead)
+    instrument_list = get_list_of_instruments_to_auto_cycle(api.data, days_ahead=days_ahead)
 
     for instrument_code in instrument_list:
-        roll_data = setup_roll_data_with_state_reporting(data, instrument_code)
+        roll_data = setup_roll_data_with_state_reporting(api.data, instrument_code)
         roll_state_required = auto_selected_roll_state_instrument(
-            data=data, roll_data=roll_data, auto_parameters=auto_parameters
+            api=api, roll_data=roll_data, auto_parameters=auto_parameters
         )
 
         if roll_state_required is no_change_required:
             warn_not_rolling(instrument_code, auto_parameters)
         else:
             modify_roll_state(
-                data=data,
+                data=api.data,
                 instrument_code=instrument_code,
                 original_roll_state=roll_data.original_roll_status,
                 roll_state_required=roll_state_required,
@@ -164,15 +165,15 @@ def update_roll_status_auto_cycle_manual_confirm(data: dataBlob):
             )
 
 
-def update_roll_status_full_auto(data: dataBlob):
+def update_roll_status_full_auto(api: reportingApi):
     days_ahead = get_days_ahead_to_consider_when_auto_cycling()
-    instrument_list = get_list_of_instruments_to_auto_cycle(data, days_ahead=days_ahead)
+    instrument_list = get_list_of_instruments_to_auto_cycle(api.data, days_ahead=days_ahead)
     auto_parameters = get_auto_roll_parameters()
 
     for instrument_code in instrument_list:
-        roll_data = setup_roll_data_with_state_reporting(data, instrument_code)
+        roll_data = setup_roll_data_with_state_reporting(api.data, instrument_code)
         roll_state_required = auto_selected_roll_state_instrument(
-            data=data, roll_data=roll_data, auto_parameters=auto_parameters
+            api=api, roll_data=roll_data, auto_parameters=auto_parameters
         )
 
         if roll_state_required is no_change_required:
@@ -180,7 +181,7 @@ def update_roll_status_full_auto(data: dataBlob):
         else:
 
             modify_roll_state(
-                data=data,
+                data=api.data,
                 instrument_code=instrument_code,
                 original_roll_state=roll_data.original_roll_status,
                 roll_state_required=roll_state_required,
@@ -299,14 +300,14 @@ def get_state_to_use_for_held_position() -> RollState:
 
 
 def auto_selected_roll_state_instrument(
-    data: dataBlob,
+    api: reportingApi,
     roll_data: RollDataWithStateReporting,
     auto_parameters: autoRollParameters,
 ) -> RollState:
 
     if roll_data.relative_volume < auto_parameters.min_volume:
 
-        run_roll_report(data, roll_data.instrument_code)
+        run_roll_report(api, roll_data.instrument_code)
         print_with_landing_strips_around(
             "For %s relative volume of %f is less than minimum of %s : NOT AUTO ROLLING"
             % (
@@ -320,7 +321,7 @@ def auto_selected_roll_state_instrument(
     no_position_held = roll_data.position_priced_contract == 0
 
     if no_position_held:
-        run_roll_report(data, roll_data.instrument_code)
+        run_roll_report(api, roll_data.instrument_code)
         print_with_landing_strips_around(
             "No position held, auto rolling adjusted price for %s"
             % roll_data.instrument_code
@@ -328,7 +329,7 @@ def auto_selected_roll_state_instrument(
         return roll_adj_state
 
     if auto_parameters.manual_prompt_for_position:
-        run_roll_report(data, roll_data.instrument_code)
+        run_roll_report(api, roll_data.instrument_code)
         roll_state_required = get_roll_state_required(roll_data)
         return roll_state_required
 
@@ -359,10 +360,10 @@ def warn_not_rolling(instrument_code: str, auto_parameters: autoRollParameters):
 
 
 def manually_report_and_update_roll_state_for_code(
-    data: dataBlob, instrument_code: str
+    api: reportingApi, instrument_code: str
 ):
-    run_roll_report(data, instrument_code)
-    manually_update_roll_state_for_code(data, instrument_code)
+    run_roll_report(api, instrument_code)
+    manually_update_roll_state_for_code(api.data, instrument_code)
 
 
 def manually_update_roll_state_for_code(data: dataBlob, instrument_code: str):
@@ -385,10 +386,10 @@ def manually_update_roll_state_for_code(data: dataBlob, instrument_code: str):
     return success
 
 
-def run_roll_report(data: dataBlob, instrument_code: str):
+def run_roll_report(api: reportingApi, instrument_code: str):
     config = roll_report_config.new_config_with_modified_output("console")
-    config.modify_kwargs(instrument_code=instrument_code)
-    report_results = run_report_with_data_blob(config, data)
+    config.modify_kwargs(instrument_code=instrument_code, reporting_api=api)
+    report_results = run_report_with_data_blob(config, api.data)
     if report_results is failure:
         raise Exception("Can't run roll report, so can't change status")
 

--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -134,7 +134,9 @@ def update_roll_status_manual_cycle(api: reportingApi):
 
 def update_roll_status_auto_cycle_manual_decide(api: reportingApi):
     days_ahead = get_days_ahead_to_consider_when_auto_cycling()
-    instrument_list = get_list_of_instruments_to_auto_cycle(api.data, days_ahead=days_ahead)
+    instrument_list = get_list_of_instruments_to_auto_cycle(
+        api.data, days_ahead=days_ahead
+    )
     for instrument_code in instrument_list:
         manually_report_and_update_roll_state_for_code(
             api=api, instrument_code=instrument_code
@@ -146,7 +148,9 @@ def update_roll_status_auto_cycle_manual_decide(api: reportingApi):
 def update_roll_status_auto_cycle_manual_confirm(api: reportingApi):
     days_ahead = get_days_ahead_to_consider_when_auto_cycling()
     auto_parameters = get_auto_roll_parameters()
-    instrument_list = get_list_of_instruments_to_auto_cycle(api.data, days_ahead=days_ahead)
+    instrument_list = get_list_of_instruments_to_auto_cycle(
+        api.data, days_ahead=days_ahead
+    )
 
     for instrument_code in instrument_list:
         roll_data = setup_roll_data_with_state_reporting(api.data, instrument_code)
@@ -168,7 +172,9 @@ def update_roll_status_auto_cycle_manual_confirm(api: reportingApi):
 
 def update_roll_status_full_auto(api: reportingApi):
     days_ahead = get_days_ahead_to_consider_when_auto_cycling()
-    instrument_list = get_list_of_instruments_to_auto_cycle(api.data, days_ahead=days_ahead)
+    instrument_list = get_list_of_instruments_to_auto_cycle(
+        api.data, days_ahead=days_ahead
+    )
     auto_parameters = get_auto_roll_parameters()
 
     for instrument_code in instrument_list:

--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -53,8 +53,9 @@ EXIT_CODE = "EXIT"
 def interactive_update_roll_status():
 
     with dataBlob(log_name="Interactive_Update-Roll-Status") as data:
+        api = reportingApi(data)
         function_to_call = get_rolling_master_function()
-        function_to_call(data)
+        function_to_call(api)
 
 
 def get_rolling_master_function():


### PR DESCRIPTION
Re-use reportingApi object to take advantage of caching.

Currently, the roll report is generated for all instruments on each iteration.  The results are already cached in the API object, but that object is thrown away and a new one created on each iteration (instrument).

By re-using the API object, instrument roll reports after the first one can be retrieved from cache nearly instantaneously.