### PR TITLE
Use Pandas NaT for missing control start/end time

### DIFF
--- a/syscore/pandas/pdutils.py
+++ b/syscore/pandas/pdutils.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from typing import Union, List
 import numpy as np
 
-from syscore.constants import named_object, missing_data, arg_not_supplied
+from syscore.constants import named_object, arg_not_supplied
 
 DEFAULT_DATE_FORMAT_FOR_CSV = "%Y-%m-%d %H:%M:%S"
 

--- a/syscore/pandas/pdutils.py
+++ b/syscore/pandas/pdutils.py
@@ -300,11 +300,9 @@ def make_df_from_list_of_named_tuple(
 
 
 def sort_df_ignoring_missing(df: pd.DataFrame, column: List[str]) -> pd.DataFrame:
-    # sorts df by column, with rows containing missing_data coming at the end
-    missing = df[df[column] == missing_data]
-    valid = df[df[column] != missing_data]
-    valid_sorted = valid.sort_values(column)
-    return pd.concat([valid_sorted, missing])
+    # sorts df by column, with rows with missing data coming at the end
+    # Pandas treats NaN, NaT, and None as missing
+    return df.sort_values(column, na_position="last")
 
 
 def apply_with_min_periods(

--- a/sysproduction/reporting/data/status.py
+++ b/sysproduction/reporting/data/status.py
@@ -4,7 +4,6 @@ import pandas as pd
 
 from syscore.exceptions import missingData
 from syscore.genutils import transfer_object_attributes
-from syscore.constants import missing_data
 from syscore.pandas.pdutils import (
     make_df_from_list_of_named_tuple,
     sort_df_ignoring_missing,
@@ -312,12 +311,12 @@ def get_control_data_for_single_ordinary_method(data, method_name_and_process):
     try:
         last_start = data_control.when_method_last_started(process_name, method)
     except missingData:
-        last_start = missing_data
+        last_start = pd.NaT
 
     try:
         last_end = data_control.when_method_last_ended(process_name, method)
     except missingData:
-        last_end = missing_data
+        last_end = pd.NaT
 
     currently_running = data_control.method_currently_running(process_name, method)
 


### PR DESCRIPTION
This might be a little controversial...

Instead of using missing_data as a sentinel value for missing datetimes, use the one Pandas provides.

Side-benefit: can use Pandas sorting function instead of writing your own