### PR TITLE
Fix: Get data without subscription #1015

### DIFF
--- a/sysbrokers/IB/client/ib_price_client.py
+++ b/sysbrokers/IB/client/ib_price_client.py
@@ -53,7 +53,6 @@ class ibPriceClient(ibContractsClient):
         specific_log = contract_object_with_ib_broker_config.specific_log(self.log)
 
         try:
-            self.ib.reqMarketDataType(3)
             ibcontract = self.ib_futures_contract(
                 contract_object_with_ib_broker_config, allow_expired=allow_expired
             )
@@ -267,6 +266,7 @@ class ibPriceClient(ibContractsClient):
         last_call = self.last_historic_price_calltime
         _avoid_pacing_violation(last_call, log=log)
 
+        self.ib.reqMarketDataType(3)
         bars = self.ib.reqHistoricalData(
             ibcontract,
             endDateTime="",

--- a/sysbrokers/IB/client/ib_price_client.py
+++ b/sysbrokers/IB/client/ib_price_client.py
@@ -53,6 +53,7 @@ class ibPriceClient(ibContractsClient):
         specific_log = contract_object_with_ib_broker_config.specific_log(self.log)
 
         try:
+            self.ib.reqMarketDataType(3)
             ibcontract = self.ib_futures_contract(
                 contract_object_with_ib_broker_config, allow_expired=allow_expired
             )


### PR DESCRIPTION
Hi Rob,
For me, this seems to fix #1015 . It seems like IB automatically switches back to live data in a callback and, in fact, it uses live data if it is available (according to the documentation). This just allows the API to retrieve delayed data if live data is not available.

PS By the way, I loved your new book. I finished the whole thing in two sittings (one of them being a full transatlantic flight). :-) It answered many of the questions I had had: for example, I'd been wondering for a while about calculating the correct carry for ags and other seasonal instruments. Excellent that you checked it! Pretty surprising that it didn't help! I also really liked your approach to reasoning about the power of diversification and your way of getting around small static portfolios simply getting lucky in their choice of instruments.