### PR TITLE
Allow optional auto creation of MongoDB compound index

### DIFF
--- a/sysdata/mongodb/mongo_generic.py
+++ b/sysdata/mongodb/mongo_generic.py
@@ -9,6 +9,7 @@ from sysdata.mongodb.mongo_connection import (
     mongo_clean_ints,
     clean_mongo_host,
 )
+from syslogdiag.log_to_screen import logtoscreen
 
 
 class mongoDataWithSingleKey(object):
@@ -162,36 +163,46 @@ class mongoDataWithMultipleKeys(object):
     """
     Read and write data class to get data from a mongo database
 
-    Use this if you aren't using a specific key as the index
-
+    Use this if you want a collection with a compound index, ie if you need to
+    search for documents using more than one field
     """
 
-    def __init__(self, collection_name: str, mongo_db=arg_not_supplied):
-        self.init_mongo(collection_name, mongo_db=mongo_db)
+    def __init__(
+        self,
+        collection_name: str,
+        mongo_db=arg_not_supplied,
+        index_config: dict = None,
+    ):
+        self._log = logtoscreen("mongoDataWithMultipleKeys", log_level="on")
+        self.init_mongo(collection_name, mongo_db=mongo_db, index_config=index_config)
 
     def init_mongo(
         self,
         collection_name: str,
         mongo_db=arg_not_supplied,
+        index_config=None,
     ):
-        mongo_object = mongoConnection(collection_name, mongo_db=mongo_db)
+        self._mongo = mongoConnection(collection_name, mongo_db=mongo_db)
 
-        self._mongo = mongo_object
+        if index_config:
+            try:
+                self._mongo.create_compound_index(index_config)
+            except Exception as exc:
+                self._log.error(
+                    "Failed to create compound index for collection '%s', "
+                    "check config: %s" % (collection_name, exc),
+                )
 
     def __repr__(self):
         return self.name
 
     @property
     def name(self) -> str:
-        mongo_object = self._mongo
-        name = "mongoData connection for mongodb %s/%s @ %s -p %s " % (
-            mongo_object.database_name,
-            mongo_object.collection_name,
-            mongo_object.host,
-            mongo_object.port,
-        )
+        col = self._mongo.collection_name
+        db = self._mongo.database_name
+        host = clean_mongo_host(self._mongo.host)
 
-        return name
+        return f"mongoData connection for {col}/{db}, {host}"
 
     def get_list_of_all_dicts(self) -> list:
         cursor = self._mongo.collection.find()

--- a/syslogdiag/mongo_email_control.py
+++ b/syslogdiag/mongo_email_control.py
@@ -1,4 +1,5 @@
 import datetime
+import pymongo
 from syscore.dateutils import datetime_to_long, long_to_datetime
 from syslogdiag.email_control import emailControlData
 from sysdata.mongodb.mongo_generic import mongoDataWithMultipleKeys
@@ -13,6 +14,14 @@ SUBJECT_KEY = "subject"
 BODY_KEY = "body"
 TYPE_KEY = "type"
 DATE_KEY = "datetime"
+INDEX_CONFIG = {
+    "keys": {
+        TYPE_KEY: pymongo.ASCENDING,
+        SUBJECT_KEY: pymongo.ASCENDING,
+        DATE_KEY: pymongo.DESCENDING,
+    },
+    "unique": True,
+}
 
 
 class mongoEmailControlData(emailControlData):
@@ -20,7 +29,9 @@ class mongoEmailControlData(emailControlData):
 
         super().__init__(log=log)
         self._mongo_data = mongoDataWithMultipleKeys(
-            EMAIL_CONTROL_COLLECTION, mongo_db=mongo_db
+            EMAIL_CONTROL_COLLECTION,
+            mongo_db=mongo_db,
+            index_config=INDEX_CONFIG,
         )
 
     def __repr__(self):


### PR DESCRIPTION
Fix for #1089. For data classes that use `mongoDataWithMultipleKeys`, we now attempt to create a MongoDB compound key if the following are true:
- the data class passes a suitable index configuration to the `init()` method
- there is not more than one index already defined
- there are no existing compound indexes
- there is no existing index using our naming format

This PR provides an index configuration for the EMAIL_CONTROL collection. The other collections which use `mongoDataWithMultipleKeys` (overide_status, position_limit_status, limit_status) have not been configured.