### PR TITLE
Possible bugfix in stack handler

### DIFF
--- a/sysbrokers/IB/client/ib_price_client.py
+++ b/sysbrokers/IB/client/ib_price_client.py
@@ -76,8 +76,7 @@ class ibPriceClient(ibContractsClient):
     ) -> tickerWithBS:
 
         ib_ticker = self.get_ib_ticker_object(
-            contract_object_with_ib_data,
-            trade_list_for_multiple_legs
+            contract_object_with_ib_data, trade_list_for_multiple_legs
         )
         if trade_list_for_multiple_legs is None:
             ib_BS_str = ""

--- a/sysbrokers/IB/client/ib_price_client.py
+++ b/sysbrokers/IB/client/ib_price_client.py
@@ -75,7 +75,10 @@ class ibPriceClient(ibContractsClient):
         trade_list_for_multiple_legs: tradeQuantity = None,
     ) -> tickerWithBS:
 
-        ib_ticker = self.get_ib_ticker_object(contract_object_with_ib_data)
+        ib_ticker = self.get_ib_ticker_object(
+            contract_object_with_ib_data,
+            trade_list_for_multiple_legs
+        )
         if trade_list_for_multiple_legs is None:
             ib_BS_str = ""
         else:


### PR DESCRIPTION
This looks like a bug to me.  

It was failing because downstream, a spread order is expected to have this argument populated, but it is not passed in here, even though it is available.

This fixed the problem for me.