### PR TITLE
Show instrument when updating spread data

### DIFF
--- a/sysinit/futures/repocsv_spread_costs.py
+++ b/sysinit/futures/repocsv_spread_costs.py
@@ -95,7 +95,9 @@ def process_modified_instruments(
 
         if check_on_modify:
             okay_to_modify = true_if_answer_is_yes(
-                "Okay to replace %f with %f" % (existing_spread, new_spread)
+                "%s: Okay to replace %f with %f" % (
+                    instrument_code, existing_spread, new_spread
+                )
             )
             if not okay_to_modify:
                 continue


### PR DESCRIPTION
When updating spread data from csv, the current prompt shows the old and new spread cost, but not the instrument