### PR TITLE
Raise exception when contract not found

### DIFF
--- a/sysbrokers/IB/ib_futures_contract_price_data.py
+++ b/sysbrokers/IB/ib_futures_contract_price_data.py
@@ -283,9 +283,9 @@ class ibFuturesContractPriceData(brokerFuturesContractPriceData):
                     futures_contract
                 )
             )
-        except missingContract:
+        except missingContract as e:
             new_log.warning("Can't get data for %s" % str(futures_contract))
-            return futuresContractPrices.create_empty()
+            raise e
 
         ticker_with_bs = self.ib_client.get_ticker_object_with_BS(
             contract_object_with_ib_data,


### PR DESCRIPTION
If this ever happened, it would have failed downstream when a tickerObject was expected.

Raising the exception is the only reasonable thing I can think of to do here...but if you had something else in mind...