### PR TITLE
IMPORTANT: Fix bug in tick data

### DIFF
--- a/sysexecution/tick_data.py
+++ b/sysexecution/tick_data.py
@@ -9,7 +9,6 @@ from syscore.exceptions import missingData
 from syscore.constants import arg_not_supplied
 
 TICK_REQUIRED_COLUMNS = ["bid_price", "ask_price", "bid_size", "ask_size"]
-TICK_REQUIRED_COLUMNS.sort()
 
 
 class dataFrameOfRecentTicks(pd.DataFrame):
@@ -17,13 +16,11 @@ class dataFrameOfRecentTicks(pd.DataFrame):
         super().__init__(*args, **kwargs)
         columns = self.columns
         sorted_columns = sorted(columns)
+        expected_columns = sorted(TICK_REQUIRED_COLUMNS)
 
-        try:
-            assert all([x == y for x, y in zip(sorted_columns, TICK_REQUIRED_COLUMNS)])
-        except:
-            raise Exception(
-                "historical ticks should have columns %s" % str(TICK_REQUIRED_COLUMNS)
-            )
+        assert all([x == y for x, y in zip(sorted_columns, expected_columns)]), (
+            "historical ticks should have columns %s" % str(expected_columns)
+        )
 
     def average_bid_offer_spread(self, remove_negative=True) -> float:
         return average_bid_offer_spread(self, remove_negative=remove_negative)


### PR DESCRIPTION
Prior to this fix, results in oneTick objects looking like this:

`oneTick(ask_price=0.21125, ask_size=0.2113, bid_price=8.0, bid_size=98.0)

!!!!