### PR TITLE
Fix: Support non-SSL SMTP

### DIFF
--- a/syslogdiag/emailing.py
+++ b/syslogdiag/emailing.py
@@ -86,7 +86,11 @@ def _send_msg(msg: MIMEMultipart):
 
     # Send the message via our own SMTP server, but don't include the
     # envelope header.
-    s = smtplib.SMTP_SSL(email_server, email_port)
+    s: smtplib.SMTP
+    try:
+        s = smtplib.SMTP_SSL(email_server, email_port)
+    except ssl.SSLError:
+        s = smtplib.SMTP(email_server, email_port)
 
     try:
         s.starttls()


### PR DESCRIPTION
This fix adds support for SMTP non-encrypted connections (on port 587 rather than 465).

The encrypted connection is tried first, and only if an exception is raised the unencrypted mode (which will be set to encrypted afterwards by calling `starttls()`) is tried. Hence this patch should not break any client which was sending emails before.