### PR TITLE
Fix to use timdelta.total_seconds()

### DIFF
--- a/sysobjects/production/process_control.py
+++ b/sysobjects/production/process_control.py
@@ -301,7 +301,7 @@ class controlProcess(object):
 
         time_now = datetime.datetime.now()
         time_delta = time_now - end_time
-        if time_delta.seconds <= SECONDS_PER_DAY:
+        if time_delta.total_seconds() <= SECONDS_PER_DAY:
             return True
         else:
             return False


### PR DESCRIPTION
Instead of using the .seconds which is normalized to 0 <= seconds < 3600*24 per https://docs.python.org/3/library/datetime.html