### PR TITLE
Fix strategy_report filing when `risk_overlay` is not configured

### DIFF
--- a/sysproduction/strategy_code/report_system_classic.py
+++ b/sysproduction/strategy_code/report_system_classic.py
@@ -529,7 +529,11 @@ def risk_scaling_string(backtest) -> str:
         backtest_system_portfolio_stage.get_leverage_for_original_position().iloc[-1]
     )
     percentage_vol_target = backtest_system_portfolio_stage.get_percentage_vol_target()
-    risk_scalar_final = backtest_system_portfolio_stage.get_risk_scalar().iloc[-1]
+    risk_scalar = backtest_system_portfolio_stage.get_risk_scalar()
+    if type(risk_scalar) is pd.Series:
+        risk_scalar_final = risk_scalar.iloc[-1]
+    else:
+        risk_scalar_final = risk_scalar
     risk_overlay_config = (
         backtest_system_portfolio_stage.config.get_element_or_arg_not_supplied(
             "risk_overlay"


### PR DESCRIPTION
`get_risk_scalar()` returns 1.0 when `risk_overlay` is not configured and which causes failing in strategy_report.