### PR TITLE
force roll state bug fixes

### DIFF
--- a/sysexecution/order_stacks/contract_order_stack.py
+++ b/sysexecution/order_stacks/contract_order_stack.py
@@ -87,7 +87,7 @@ class contractOrderStackData(orderStackData):
         list_of_orders = [
             order
             for order in list_of_orders
-            if order.instrument_code is instrument_code
+            if order.instrument_code == instrument_code
         ]
 
         return list_of_orders

--- a/sysexecution/order_stacks/instrument_order_stack.py
+++ b/sysexecution/order_stacks/instrument_order_stack.py
@@ -19,7 +19,7 @@ class instrumentOrderStackData(orderStackData):
         list_of_orders = [
             order
             for order in list_of_orders
-            if order.instrument_code is instrument_code
+            if order.instrument_code == instrument_code
         ]
 
         return list_of_orders


### PR DESCRIPTION
fixes a couple of bugs introduced by the solution for #1193. The first can cause force roll orders to be created, even though there are already orders for the same instrument. This is the cause of the issues in #1278.

I found the second one I found by doing a text search for the same bug. It looks like the code is supposed to prevent you setting force roll state when there are already orders for the instrument, but it never happens. 