### PR TITLE
docs: update ARM64 MacOS installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -136,26 +136,13 @@ And now install the dependencies
 
 ### MacOS (ARM)
 
-If you're running MacOS on one of the new ARM chips, the process is more complex. You'll need Homebrew and the Apple XCode Commandline Development Tools, configured for ARM. Doing that is beyond the scope of this document, type `homebrew apple xcode command line tools` into your favourite search engine. Once installed and configured, install *cython*:
+If you're running MacOS on one of the new ARM chips, the process is more complex. You'll need Homebrew and the Apple XCode Commandline Development Tools, configured for ARM. Doing that is beyond the scope of this document, type `homebrew apple xcode command line tools` into your favourite search engine. Once installed and configured, run installation script:
 
 ```
-(3.8.16) $ OPENBLAS="$(brew --prefix openblas)" MACOSX_DEPLOYMENT_TARGET=12.6 python -m pip install cython --no-use-pep517
+chmod u+x install install_dependencies_apple_silicon.sh
+./install_dependencies_apple_silicon.sh
 ```
-
-Then the key dependencies
-
-```
-(3.8.16) $ OPENBLAS="$(brew --prefix openblas)" MACOSX_DEPLOYMENT_TARGET=12.6 python -m pip install "numpy>=1.19.4,<1.24.0" --no-use-pep517
-(3.8.16) $ OPENBLAS="$(brew --prefix openblas)" MACOSX_DEPLOYMENT_TARGET=12.6 python -m pip install scipy --no-use-pep517
-(3.8.16) $ OPENBLAS="$(brew --prefix openblas)" MACOSX_DEPLOYMENT_TARGET=12.6 python -m pip install pandas==1.0.5 --no-use-pep517
-(3.8.16) $ OPENBLAS="$(brew --prefix openblas)" MACOSX_DEPLOYMENT_TARGET=12.6 python -m pip install statsmodels==0.12.2 --no-use-pep517
-```
-
-Then the remaining dependencies
-
-```
-(3.8.16) $ pip install -r requirements.txt
-```
+Note: this may (unfortunately) become out of date and require some tweaking.
 
 ### Check dependencies, all OSs
 

--- a/install_dependencies_apple_silicon.sh
+++ b/install_dependencies_apple_silicon.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Cython 3.0.0 is not supported by pandas 1.0.5
+python -m pip install "cython<3.0.0" wheel
+python -m pip install pyyaml==5.4.1 --no-build-isolation
+python -m pip install "numpy>=1.19.4,<1.24.0" --no-use-pep517
+python -m pip install scipy --no-use-pep517
+python -m pip install pandas==1.0.5 --no-use-pep517
+python -m pip install statsmodels==0.12.2 --no-use-pep517
+
+pip install -r requirements_apple_silicon.txt

--- a/requirements_apple_silicon.txt
+++ b/requirements_apple_silicon.txt
@@ -1,0 +1,9 @@
+matplotlib>=3.0.0
+pymongo==3.11.3
+arctic==1.79.2
+ib-insync==0.9.86
+psutil==5.6.6
+pytest>6.2
+Flask>=2.0.1
+Werkzeug>=2.0.1
+PyPDF2>=2.5.0


### PR DESCRIPTION
RFC: Not necessarily something you would consider merging, as its probably quite likely to go out of date - but this is how I managed to get the requirements installed on Apple Silicon after some trial and error, as the existing steps were throwing up some errors.

Install Script tested in a clean Python 3.8.16 venv, on macOS 12.6.2, xcode-select version 2395.