### PR TITLE
TypeError in build_roll_calendars

### DIFF
--- a/sysinit/futures/build_roll_calendars.py
+++ b/sysinit/futures/build_roll_calendars.py
@@ -477,15 +477,21 @@ def _matching_prices_from_paired_prices(paired_prices):
 
 
 def _valid_dates_from_matching_prices(paired_prices_matching, avoid_date):
-    valid_dates = paired_prices_matching.index
-    valid_dates.sort_values()
-
+    # Ensure the index is a DatetimeIndex
+    valid_dates = pd.to_datetime(paired_prices_matching.index)
+    
+    # Sort the dates; necessary because we're about to perform a comparison operation
+    valid_dates = valid_dates.sort_values()
+    
     if avoid_date is not None:
-        # Remove matching dates before avoid dates
+        # Convert avoid_date to Timestamp if it's not already one
+        if not isinstance(avoid_date, pd.Timestamp):
+            avoid_date = pd.Timestamp(avoid_date)
+        
+        # Remove dates before the 'avoid_date'
         valid_dates = valid_dates[valid_dates > avoid_date]
 
     return valid_dates
-
 
 def _find_closest_valid_date_to_approx_roll_date(valid_dates, roll_date):
     distance_to_roll = valid_dates - roll_date


### PR DESCRIPTION
-     Datetime Conversion: pd.to_datetime() ensures that valid_dates is in the correct format. This is especially important if the index might not originally be in datetime format.
-     Sorting Correctly: valid_dates = valid_dates.sort_values() ensures that the data is sorted after conversion. This is crucial for correct filtering based on date.
-     Type Checking: The type check for avoid_date ensures that the comparison operation will not fail due to incompatible types.

I was encountering the following error when building roll calendars from IB seed data which this addresses:
```
  File "/home/trader/pysystemtrade/sysobjects/roll_calendars.py", line 56, in create_from_prices
    adjusted_calendar = adjust_to_price_series(
  File "/home/trader/pysystemtrade/sysinit/futures/build_roll_calendars.py", line 199, in adjust_to_price_series
    adjusted_row = _adjust_row_of_approx_roll_calendar(
  File "/home/trader/pysystemtrade/sysinit/futures/build_roll_calendars.py", line 280, in _adjust_row_of_approx_roll_calendar
    adjusted_roll_date = _find_best_matching_roll_date(
  File "/home/trader/pysystemtrade/sysinit/futures/build_roll_calendars.py", line 431, in _find_best_matching_roll_date
    valid_dates = _valid_dates_from_paired_prices(paired_prices, avoid_date)
  File "/home/trader/pysystemtrade/sysinit/futures/build_roll_calendars.py", line 465, in _valid_dates_from_paired_prices
    valid_dates = _valid_dates_from_matching_prices(paired_prices_matching, avoid_date)
  File "/home/trader/pysystemtrade/sysinit/futures/build_roll_calendars.py", line 485, in _valid_dates_from_matching_prices
    valid_dates = valid_dates[valid_dates > avoid_date]
  File "/home/trader/.local/lib/python3.10/site-packages/pandas/core/ops/common.py", line 76, in new_method
    return method(self, other)
  File "/home/trader/.local/lib/python3.10/site-packages/pandas/core/arraylike.py", line 56, in __gt__
    return self._cmp_method(other, operator.gt)
  File "/home/trader/.local/lib/python3.10/site-packages/pandas/core/indexes/base.py", line 7124, in _cmp_method
    result = ops.comparison_op(self._values, other, op)
  File "/home/trader/.local/lib/python3.10/site-packages/pandas/core/ops/array_ops.py", line 332, in comparison_op
    res_values = op(lvalues, rvalues)
TypeError: '>' not supported between instances of 'numpy.ndarray' and 'Timestamp'
```
