### PR TITLE
repocsv_spotfx_prices requires child class of FxPricesData

### DIFF
--- a/sysinit/futures/repocsv_spotfx_prices.py
+++ b/sysinit/futures/repocsv_spotfx_prices.py
@@ -4,9 +4,14 @@ Get FX prices from csv repo files and write to arctic
 WARNING WILL OVERWRITE EXISTING!
 """
 from sysdata.csv.csv_spot_fx import csvFxPricesData
-from sysproduction.data.currency_data import fxPricesData
+from sysdata.parquet.parquet_spotfx_prices import parquetFxPricesData
+from sysdata.data_blob import dataBlob  # Update with correct import path
 
-db_fx_price_data = fxPricesData()
+# Create a dataBlob instance which automatically uses the default parquet_store_path from the config
+blob = dataBlob()
+
+# Use the parquet_access from blob to create parquetFxPricesData
+db_fx_price_data = parquetFxPricesData(parquet_access=blob.parquet_access)
 
 if __name__ == "__main__":
     input("Will overwrite existing prices are you sure?! CTL-C to abort")
@@ -16,6 +21,7 @@ if __name__ == "__main__":
     currency_code = input("Currency code? <return for ALL currencies> ")
     if currency_code == "":
         list_of_ccy_codes = csv_fx_prices.get_list_of_fxcodes()
+        print(list_of_ccy_codes)
     else:
         list_of_ccy_codes = [currency_code]
 


### PR DESCRIPTION
Issue:

Encountered a NotImplementedError(USE_CHILD_CLASS_ERROR) when attempting to initialize and populate the FX prices database using the add_fx_prices method from the fxPricesData class. This error was due to the direct instantiation of fxPricesData, an abstract base class, which lacks implementations for required methods like _add_fx_prices_without_checking_for_existing_entry.

Resolution:
To resolve this, we switched to using parquetFxPricesData, a subclass of fxPricesData that properly implements all abstract methods required for handling FX prices stored in Parquet format. However, parquetFxPricesData requires a ParquetAccess instance initialized with a parquet_store_path, which can be dynamically retrieved from the project's configuration settings via dataBlob.

Testing:

    Verified that the script correctly initializes and populates the FX prices without encountering NotImplementedError.