### PR TITLE
add visualization example

### DIFF
--- a/examples/visualize/configs/futures_system.yaml
+++ b/examples/visualize/configs/futures_system.yaml
@@ -1,0 +1,128 @@
+defaults:
+    - _self_
+    - trading_rules:
+        - accel16
+        - accel32
+        - accel64
+        - assettrend2
+        - assettrend4
+        - assettrend8
+        - assettrend16
+        - assettrend32
+        - breakout10
+        - breakout20
+        - breakout40
+        - breakout80
+        - breakout160
+        - breakout320
+        - carry10
+        - carry30
+        - carry90
+        - carry125
+        - ewmac2_8
+        - ewmac4_16
+        - ewmac8_32
+        - ewmac16_64
+        - ewmac32_128
+        - ewmac64_256
+        - momentum4
+        - momentum8
+        - momentum16
+        - momentum32
+        - momentum64
+        - mrinasset1000
+        - normnorm2
+        - normnorm4
+        - normnorm8
+        - normnorm16
+        - normnorm32
+        - normnorm64
+        - relcarry
+        - relmomentum10
+        - relmomentum20
+        - relmomentum40
+        - relmomentum80
+        - skewabs365
+        - skewrv180
+        - skewrv365
+
+name: futures_default
+# rule_variations: []
+
+# Forecast
+use_forecast_scale_estimates: True
+forecast_scale_estimates:
+    pool_instruments: True
+volatility_calculation:
+    func: "sysquant.estimators.vol.mixed_vol_calc"
+    days: 35
+    min_periods: 10
+    vol_abs_min: 0.0000000001
+    slow_vol_years: 20
+    proportion_of_slow_vol: 0.35
+    backfill: True
+
+# Forecast combination
+use_forceast_weight_estimates: True
+use_forecast_div_mult_estimates: True
+forecast_correlation_estimate:
+    pool_instruments: True
+
+use_attenuation:
+   - 'breakout10'
+   - 'breakout20'
+   - 'breakout40'
+   - 'breakout80'
+   - 'breakout160'
+   - 'breakout320'
+   - 'relmomentum10'
+   - 'relmomentum20'
+   - 'relmomentum40'
+   - 'relmomentum80'
+   - 'mrinasset1000'
+   - 'assettrend2'
+   - 'assettrend4'
+   - 'assettrend8'
+   - 'assettrend16'
+   - 'assettrend32'
+   - 'assettrend64'
+   - 'normmom2'
+   - 'normmom4'
+   - 'normmom8'
+   - 'normmom16'
+   - 'normmom32'
+   - 'normmom64'
+   - 'momentum4'
+   - 'momentum8'
+   - 'momentum16'
+   - 'momentum32'
+   - 'momentum64'
+
+# Instrument weighting
+use_instrument_weight_estimates: True
+use_instrument_div_mult_estimates: True
+instrument_div_multiplier: 2.75
+risk_overlay:
+    max_risk_fraction_normal_risk: 1.75
+    max_risk_fraction_stdev_risk: 4.0
+    max_risk_limit_sum_abs_risk: 4.0
+    max_risk_leverage: 20.0
+
+# Capital correction
+percentage_vol_target: 25.0
+notional_trading_capital: 500000
+base_currency: "USD"
+
+# Portfolio creation
+instruments: [AEX, CANOLA, GILT]
+
+# Misc
+n_threads: 40
+log_dir: ./exp_local/${now:%Y.%m.%d}/${now:%H%M%S}
+load_model: True
+save_model: False
+model_loc: private/models/futures_default/system
+
+hydra:
+    run:
+        dir: ./exp_local/${now:%Y.%m.%d}

--- a/examples/visualize/configs/system.yaml
+++ b/examples/visualize/configs/system.yaml
@@ -1,0 +1,41 @@
+defaults:
+    - _self_
+    - trading_rules:
+        - ewmac16_64
+        - ewmac32_128
+        - ewmac64_256
+        - carry90
+
+name: simple_default
+rule_variations: ['ewmac16_64', 'ewmac32_128', 'ewmac64_256', 'carry90']
+
+# Forecast
+use_forecast_scale_estimates: True
+forecast_scale_estimate:
+    pool_instruments: True
+
+# Forecast combination:
+use_forecast_weight_estimates: True
+use_forecast_div_mult_estimates: True
+forecast_correlation_estimate:
+    pool_instruments: True
+
+# Instrument weighting:
+use_instrument_weight_estimates: True
+use_instrument_div_mult_estimates: True
+
+# Capital correction
+percentage_vol_target: 20.0
+notional_trading_capital: 250000
+base_currency: "USD"
+
+# Misc
+use_wandb: True
+log_dir: ./exp_local/${now:%Y.%m.%d}/${now:%H%M%S}
+
+# Portfolio creation
+instruments: ["SOFR", "US10", "EUROSTX", "MXP", "CORN", "V2X"]
+
+hydra:
+    run:
+        dir: ./exp_local/${now:%Y.%m.%d}

--- a/examples/visualize/configs/trading_rules/accel16.yaml
+++ b/examples/visualize/configs/trading_rules/accel16.yaml
@@ -1,0 +1,7 @@
+accel16:
+    function: systems.provided.rules.accel.accel
+    data:
+         - "rawdata.get_daily_prices"
+         - "rawdata.daily_returns_volatility"
+    other_args:
+         Lfast: 16

--- a/examples/visualize/configs/trading_rules/accel32.yaml
+++ b/examples/visualize/configs/trading_rules/accel32.yaml
@@ -1,0 +1,7 @@
+accel32:
+    function: systems.provided.rules.accel.accel
+    data:
+         - "rawdata.get_daily_prices"
+         - "rawdata.daily_returns_volatility"
+    other_args:
+         Lfast: 32

--- a/examples/visualize/configs/trading_rules/accel64.yaml
+++ b/examples/visualize/configs/trading_rules/accel64.yaml
@@ -1,0 +1,7 @@
+accel64:
+    function: systems.provided.rules.accel.accel
+    data:
+         - "rawdata.get_daily_prices"
+         - "rawdata.daily_returns_volatility"
+    other_args:
+         Lfast: 64

--- a/examples/visualize/configs/trading_rules/assettrend16.yaml
+++ b/examples/visualize/configs/trading_rules/assettrend16.yaml
@@ -1,0 +1,7 @@
+assettrend16:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+         Lfast: 16
+         Lslow: 32

--- a/examples/visualize/configs/trading_rules/assettrend2.yaml
+++ b/examples/visualize/configs/trading_rules/assettrend2.yaml
@@ -1,0 +1,7 @@
+assettrend2:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+         Lfast: 2
+         Lslow: 8

--- a/examples/visualize/configs/trading_rules/assettrend32.yaml
+++ b/examples/visualize/configs/trading_rules/assettrend32.yaml
@@ -1,0 +1,7 @@
+assettrend32:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+         Lfast: 32
+         Lslow: 64

--- a/examples/visualize/configs/trading_rules/assettrend4.yaml
+++ b/examples/visualize/configs/trading_rules/assettrend4.yaml
@@ -1,0 +1,7 @@
+assettrend4:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+         Lfast: 4
+         Lslow: 8

--- a/examples/visualize/configs/trading_rules/assettrend8.yaml
+++ b/examples/visualize/configs/trading_rules/assettrend8.yaml
@@ -1,0 +1,7 @@
+assettrend8:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+         Lfast: 8
+         Lslow: 16

--- a/examples/visualize/configs/trading_rules/breakout10.yaml
+++ b/examples/visualize/configs/trading_rules/breakout10.yaml
@@ -1,0 +1,6 @@
+breakout10:
+    function: systems.provided.rules.breakout.breakout
+    data:
+        - "rawdata.get_daily_prices"
+    other_args:
+      lookback: 10

--- a/examples/visualize/configs/trading_rules/breakout160.yaml
+++ b/examples/visualize/configs/trading_rules/breakout160.yaml
@@ -1,0 +1,6 @@
+breakout160:
+    function: systems.provided.rules.breakout.breakout
+    data:
+        - "rawdata.get_daily_prices"
+    other_args:
+      lookback: 160

--- a/examples/visualize/configs/trading_rules/breakout20.yaml
+++ b/examples/visualize/configs/trading_rules/breakout20.yaml
@@ -1,0 +1,6 @@
+breakout20:
+    function: systems.provided.rules.breakout.breakout
+    data:
+        - "rawdata.get_daily_prices"
+    other_args:
+      lookback: 20

--- a/examples/visualize/configs/trading_rules/breakout320.yaml
+++ b/examples/visualize/configs/trading_rules/breakout320.yaml
@@ -1,0 +1,6 @@
+breakout320:
+    function: systems.provided.rules.breakout.breakout
+    data:
+        - "rawdata.get_daily_prices"
+    other_args:
+      lookback: 320

--- a/examples/visualize/configs/trading_rules/breakout40.yaml
+++ b/examples/visualize/configs/trading_rules/breakout40.yaml
@@ -1,0 +1,6 @@
+breakout40:
+    function: systems.provided.rules.breakout.breakout
+    data:
+        - "rawdata.get_daily_prices"
+    other_args:
+      lookback: 40

--- a/examples/visualize/configs/trading_rules/breakout80.yaml
+++ b/examples/visualize/configs/trading_rules/breakout80.yaml
@@ -1,0 +1,6 @@
+breakout80:
+    function: systems.provided.rules.breakout.breakout
+    data:
+        - "rawdata.get_daily_prices"
+    other_args:
+      lookback: 80

--- a/examples/visualize/configs/trading_rules/carry10.yaml
+++ b/examples/visualize/configs/trading_rules/carry10.yaml
@@ -1,0 +1,6 @@
+carry10:
+    function: systems.provided.rules.carry.carry
+    data:
+        - "rawdata.raw_carry"
+    other_args:
+        smooth_days: 10

--- a/examples/visualize/configs/trading_rules/carry125.yaml
+++ b/examples/visualize/configs/trading_rules/carry125.yaml
@@ -1,0 +1,6 @@
+carry125:
+    function: systems.provided.rules.carry.carry
+    data:
+        - "rawdata.raw_carry"
+    other_args:
+        smooth_days: 125

--- a/examples/visualize/configs/trading_rules/carry30.yaml
+++ b/examples/visualize/configs/trading_rules/carry30.yaml
@@ -1,0 +1,6 @@
+carry30:
+    function: systems.provided.rules.carry.carry
+    data:
+        - "rawdata.raw_carry"
+    other_args:
+        smooth_days: 30

--- a/examples/visualize/configs/trading_rules/carry60.yaml
+++ b/examples/visualize/configs/trading_rules/carry60.yaml
@@ -1,0 +1,6 @@
+carry60:
+    function: systems.provided.rules.carry.carry
+    data:
+        - "rawdata.raw_carry"
+    other_args:
+        smooth_days: 60

--- a/examples/visualize/configs/trading_rules/carry90.yaml
+++ b/examples/visualize/configs/trading_rules/carry90.yaml
@@ -1,0 +1,6 @@
+carry90:
+    function: systems.provided.rules.carry.carry
+    data:
+        - "rawdata.raw_carry"
+    other_args:
+        smooth_days: 60

--- a/examples/visualize/configs/trading_rules/ewmac16_64.yaml
+++ b/examples/visualize/configs/trading_rules/ewmac16_64.yaml
@@ -1,0 +1,8 @@
+ewmac16_64:
+    function: systems.provided.rules.ewmac.ewmac
+    data:
+        - "rawdata.get_daily_prices"
+        - "rawdata.daily_returns_volatility"
+    other_args: 
+        Lfast: 16
+        Lslow: 64

--- a/examples/visualize/configs/trading_rules/ewmac2_8.yaml
+++ b/examples/visualize/configs/trading_rules/ewmac2_8.yaml
@@ -1,0 +1,8 @@
+ewmac2_8:
+    function: systems.provided.rules.ewmac.ewmac
+    data:
+        - "rawdata.get_daily_prices"
+        - "rawdata.daily_returns_volatility"
+    other_args: 
+        Lfast: 2
+        Lslow: 8

--- a/examples/visualize/configs/trading_rules/ewmac32_128.yaml
+++ b/examples/visualize/configs/trading_rules/ewmac32_128.yaml
@@ -1,0 +1,8 @@
+ewmac32_128:
+    function: systems.provided.rules.ewmac.ewmac
+    data:
+        - "rawdata.get_daily_prices"
+        - "rawdata.daily_returns_volatility"
+    other_args: 
+        Lfast: 32
+        Lslow: 128

--- a/examples/visualize/configs/trading_rules/ewmac4_16.yaml
+++ b/examples/visualize/configs/trading_rules/ewmac4_16.yaml
@@ -1,0 +1,8 @@
+ewmac4_16:
+    function: systems.provided.rules.ewmac.ewmac
+    data:
+        - "rawdata.get_daily_prices"
+        - "rawdata.daily_returns_volatility"
+    other_args: 
+        Lfast: 4
+        Lslow: 16

--- a/examples/visualize/configs/trading_rules/ewmac64_256.yaml
+++ b/examples/visualize/configs/trading_rules/ewmac64_256.yaml
@@ -1,0 +1,8 @@
+ewmac64_256:
+    function: systems.provided.rules.ewmac.ewmac
+    data:
+        - "rawdata.get_daily_prices"
+        - "rawdata.daily_returns_volatility"
+    other_args: 
+        Lfast: 64
+        Lslow: 256

--- a/examples/visualize/configs/trading_rules/ewmac8_32.yaml
+++ b/examples/visualize/configs/trading_rules/ewmac8_32.yaml
@@ -1,0 +1,8 @@
+ewmac8_32:
+    function: systems.provided.rules.ewmac.ewmac
+    data:
+        - "rawdata.get_daily_prices"
+        - "rawdata.daily_returns_volatility"
+    other_args: 
+        Lfast: 8
+        Lslow: 32

--- a/examples/visualize/configs/trading_rules/momentum16.yaml
+++ b/examples/visualize/configs/trading_rules/momentum16.yaml
@@ -1,0 +1,8 @@
+momentum4:
+     function: systems.provided.rules.ewmac.ewmac
+     data:
+         - "rawdata.get_daily_prices"
+         - "rawdata.daily_returns_volatility"
+     other_args:
+         Lfast: 16
+         Lslow: 64

--- a/examples/visualize/configs/trading_rules/momentum32.yaml
+++ b/examples/visualize/configs/trading_rules/momentum32.yaml
@@ -1,0 +1,8 @@
+momentum32:
+     function: systems.provided.rules.ewmac.ewmac
+     data:
+         - "rawdata.get_daily_prices"
+         - "rawdata.daily_returns_volatility"
+     other_args:
+         Lfast: 32
+         Lslow: 128

--- a/examples/visualize/configs/trading_rules/momentum4.yaml
+++ b/examples/visualize/configs/trading_rules/momentum4.yaml
@@ -1,0 +1,8 @@
+momentum4:
+     function: systems.provided.rules.ewmac.ewmac
+     data:
+         - "rawdata.get_daily_prices"
+         - "rawdata.daily_returns_volatility"
+     other_args:
+         Lfast: 4
+         Lslow: 16

--- a/examples/visualize/configs/trading_rules/momentum64.yaml
+++ b/examples/visualize/configs/trading_rules/momentum64.yaml
@@ -1,0 +1,8 @@
+momentum32:
+     function: systems.provided.rules.ewmac.ewmac
+     data:
+         - "rawdata.get_daily_prices"
+         - "rawdata.daily_returns_volatility"
+     other_args:
+         Lfast: 64
+         Lslow: 256

--- a/examples/visualize/configs/trading_rules/momentum8.yaml
+++ b/examples/visualize/configs/trading_rules/momentum8.yaml
@@ -1,0 +1,8 @@
+momentum4:
+     function: systems.provided.rules.ewmac.ewmac
+     data:
+         - "rawdata.get_daily_prices"
+         - "rawdata.daily_returns_volatility"
+     other_args:
+         Lfast: 8
+         Lslow: 32

--- a/examples/visualize/configs/trading_rules/mrinasset1000.yaml
+++ b/examples/visualize/configs/trading_rules/mrinasset1000.yaml
@@ -1,0 +1,7 @@
+mrinasset1000:
+     function: systems.provided.rules.cs_mr.cross_sectional_mean_reversion
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+       horizon: 1000

--- a/examples/visualize/configs/trading_rules/normnorm16.yaml
+++ b/examples/visualize/configs/trading_rules/normnorm16.yaml
@@ -1,0 +1,7 @@
+normmom16:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+     other_args:
+         Lfast: 16
+         Lslow: 64

--- a/examples/visualize/configs/trading_rules/normnorm2.yaml
+++ b/examples/visualize/configs/trading_rules/normnorm2.yaml
@@ -1,0 +1,7 @@
+normmom2:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+     other_args:
+         Lfast: 2
+         Lslow: 8

--- a/examples/visualize/configs/trading_rules/normnorm32.yaml
+++ b/examples/visualize/configs/trading_rules/normnorm32.yaml
@@ -1,0 +1,7 @@
+normmom32:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+     other_args:
+         Lfast: 32
+         Lslow: 128

--- a/examples/visualize/configs/trading_rules/normnorm4.yaml
+++ b/examples/visualize/configs/trading_rules/normnorm4.yaml
@@ -1,0 +1,7 @@
+normmom4:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+     other_args:
+         Lfast: 4
+         Lslow: 16

--- a/examples/visualize/configs/trading_rules/normnorm64.yaml
+++ b/examples/visualize/configs/trading_rules/normnorm64.yaml
@@ -1,0 +1,7 @@
+normmom64:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+     other_args:
+         Lfast: 64
+         Lslow: 256

--- a/examples/visualize/configs/trading_rules/normnorm8.yaml
+++ b/examples/visualize/configs/trading_rules/normnorm8.yaml
@@ -1,0 +1,7 @@
+normmom8:
+     function: systems.provided.rules.ewmac.ewmac_calc_vol
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+     other_args:
+         Lfast: 8
+         Lslow: 32

--- a/examples/visualize/configs/trading_rules/relcarry.yaml
+++ b/examples/visualize/configs/trading_rules/relcarry.yaml
@@ -1,0 +1,5 @@
+relcarry:
+     function: systems.provided.rules.carry.relative_carry
+     data:
+          - "rawdata.smoothed_carry"
+          - "rawdata.median_carry_for_asset_class"

--- a/examples/visualize/configs/trading_rules/relmomentum10.yaml
+++ b/examples/visualize/configs/trading_rules/relmomentum10.yaml
@@ -1,0 +1,7 @@
+relmomentum10:
+     function: systems.provided.rules.rel_mom.relative_momentum
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+       horizon: 10

--- a/examples/visualize/configs/trading_rules/relmomentum20.yaml
+++ b/examples/visualize/configs/trading_rules/relmomentum20.yaml
@@ -1,0 +1,7 @@
+relmomentum20:
+     function: systems.provided.rules.rel_mom.relative_momentum
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+       horizon: 20

--- a/examples/visualize/configs/trading_rules/relmomentum40.yaml
+++ b/examples/visualize/configs/trading_rules/relmomentum40.yaml
@@ -1,0 +1,7 @@
+relmomentum40:
+     function: systems.provided.rules.rel_mom.relative_momentum
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+       horizon: 40

--- a/examples/visualize/configs/trading_rules/relmomentum80.yaml
+++ b/examples/visualize/configs/trading_rules/relmomentum80.yaml
@@ -1,0 +1,7 @@
+relmomentum80:
+     function: systems.provided.rules.rel_mom.relative_momentum
+     data:
+         - "rawdata.get_cumulative_daily_vol_normalised_returns"
+         - "rawdata.normalised_price_for_asset_class"
+     other_args:
+       horizon: 80

--- a/examples/visualize/configs/trading_rules/skewabs180.yaml
+++ b/examples/visualize/configs/trading_rules/skewabs180.yaml
@@ -1,0 +1,9 @@
+skewabs180:
+     function: systems.provided.rules.factors.factor_trading_rule
+     data:
+          - 'rawdata.get_demeanded_factor_value'
+     other_args:
+          smooth: 45
+          _factor_name: 'neg_skew'
+          _demean_method: 'historic_average_factor_value_all_assets'
+          _lookback_days: 180

--- a/examples/visualize/configs/trading_rules/skewabs365.yaml
+++ b/examples/visualize/configs/trading_rules/skewabs365.yaml
@@ -1,0 +1,9 @@
+skewabs365:
+     function: systems.provided.rules.factors.factor_trading_rule
+     data:
+          - 'rawdata.get_demeanded_factor_value'
+     other_args:
+          smooth: 90
+          _factor_name: 'neg_skew'
+          _demean_method: 'historic_average_factor_value_all_assets'
+          _lookback_days: 365

--- a/examples/visualize/configs/trading_rules/skewrv180.yaml
+++ b/examples/visualize/configs/trading_rules/skewrv180.yaml
@@ -1,0 +1,9 @@
+skewrv180:
+     function: systems.provided.rules.factors.factor_trading_rule
+     data:
+          - 'rawdata.get_demeanded_factor_value'
+     other_args:
+          smooth: 45
+          _factor_name: 'neg_skew'
+          _demean_method: 'average_factor_value_in_asset_class_for_instrument'
+          _lookback_days: 180

--- a/examples/visualize/configs/trading_rules/skewrv365.yaml
+++ b/examples/visualize/configs/trading_rules/skewrv365.yaml
@@ -1,0 +1,9 @@
+skewrv365:
+     function: systems.provided.rules.factors.factor_trading_rule
+     data:
+          - 'rawdata.get_demeanded_factor_value'
+     other_args:
+          smooth: 90
+          _factor_name: 'neg_skew'
+          _demean_method: 'average_factor_value_in_asset_class_for_instrument'
+          _lookback_days: 365

--- a/examples/visualize/dashtest.py
+++ b/examples/visualize/dashtest.py
@@ -1,0 +1,571 @@
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly_resampler import FigureResampler, FigureWidgetResampler
+from omegaconf import DictConfig, OmegaConf
+from pathlib import Path
+from dash import Dash, dcc, html, Input, Output
+import dash_bootstrap_components as dbc
+import hydra
+
+from typing import List
+
+from sysdata.config.configdata import Config
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
+from systems.forecasting import Rules
+from systems.basesystem import System
+from systems.forecast_combine import ForecastCombine
+from systems.forecast_scale_cap import ForecastScaleCap
+from systems.rawdata import RawData
+from systems.positionsizing import PositionSizing
+from systems.portfolio import Portfolios
+from systems.accounts.accounts_stage import Account
+
+
+class AppData:
+    
+    def __init__(self, cfg):
+        
+        # Setup dir configs
+        self.work_dir = Path.cwd()
+        self.log_dir = cfg.log_dir
+        self.cfg = cfg
+
+        # Make system and load data
+        rules_config = OmegaConf.to_container(self.cfg.trading_rules)
+        rules = Rules(rules_config)
+        data = csvFuturesSimData()
+        dict_config = OmegaConf.to_container(self.cfg)
+        config = Config(dict_config)
+        
+        self.system = System(
+            [
+                Account(),
+                Portfolios(),
+                PositionSizing(),
+                RawData(),
+                ForecastCombine(),
+                ForecastScaleCap(),
+                rules,
+            ],
+            data,
+            config
+        )
+
+    def get_dfs(self) -> dict:
+        """
+        Return the graphs used to make Dash app
+        
+        """
+        data = {}
+        instruments = self.system.get_instrument_list()
+        to_dataframe = lambda x: pd.concat(x.values(), axis=1, keys=x.keys(), join = 'outer') 
+        rule_list = list(self.cfg.trading_rules.keys())
+        
+         
+        price_dict = {}
+        comb_forecasts_dict = {}
+        raw_forecasts_dict = {}
+        forecast_scalars_dict = {}
+        forecast_turnovers_dict = {}
+        rule_weights_dict = {}
+        correlation_dict = {}
+        diversification_dict = {}
+        notional_dict = {}
+        position_dict = {}
+        
+        for instrument in instruments:
+            price_dict[instrument] = self.system.data.get_raw_price(instrument)  # raw price
+            comb_forecasts_dict[instrument] = self.system.combForecast.get_combined_forecast(instrument)  # comb forecasts
+            
+            raw_rule_forecast_dict = {}
+            forecast_scalar_dict = {}
+            forecast_turnover_dict = {}
+            for rule in rule_list:
+                raw_rule_forecast_dict[rule] = self.system.rules.get_raw_forecast(instrument, rule)
+                forecast_scalar_dict[rule] = self.system.forecastScaleCap.get_forecast_scalar(instrument, rule).tail(1).iloc[0].item()
+                forecast_turnover_dict[rule] = self.system.accounts.get_SR_cost_for_instrument_forecast(instrument, rule).item()
+            raw_forecasts_dict[instrument] = to_dataframe(raw_rule_forecast_dict)
+            forecast_scalars_dict[instrument] = forecast_scalar_dict.copy()
+            correlation_dict[instrument] = self.system.combForecast.get_forecast_correlation_matrices(instrument).corr_list[-1].as_pd()  # instrument correlation array
+             
+            rule_weights_dict[instrument] = self.system.combForecast.get_forecast_weights(instrument)  # rule weights
+            diversification_dict[instrument] = self.system.combForecast.get_forecast_diversification_multiplier(instrument)  # diversification values
+            notional_dict[instrument] = self.system.portfolio.get_notional_position(instrument)
+            position_dict[instrument] = self.system.positionSize.get_subsystem_position(instrument)
+         
+        price_df = to_dataframe(price_dict)
+        comb_forecasts_df = to_dataframe(comb_forecasts_dict)
+        rule_weights_df = to_dataframe(rule_weights_dict)
+        diversification_df = to_dataframe(diversification_dict)
+        notional_df = to_dataframe(notional_dict)
+        position_df = to_dataframe(position_dict)
+
+        data["prices"] = price_df
+        data["comb_forecasts"] = comb_forecasts_df
+        data["raw_forecasts"] = raw_forecasts_dict
+        data["forecast_scalars"] = forecast_scalars_dict
+        data["forecast_turnovers"] = forecast_turnovers_dict
+        data["rule_weights"] = rule_weights_df
+        data["correlation"] = correlation_dict
+        data["diversification"] = diversification_df
+        data["notional"] = notional_df
+        data["position"] = position_df
+        
+        portfolio = self.system.accounts.portfolio()
+        data["accumulated_returns"] = portfolio.percent.gross.curve()
+        data["drawdown"] = portfolio.percent.drawdown()
+        data["annualized_volatility"] = portfolio.percent.rolling_ann_std()
+        
+        return data
+
+
+@hydra.main(config_path='pysystemtrade/examples/visualize/configs/.', config_name='system')
+def run_app(cfg):
+   
+
+    data = AppData(cfg)
+    dfs = data.get_dfs()
+    instruments = data.system.get_instrument_list()
+    rule_list = list(cfg.trading_rules.keys())
+    portfolio = data.system.accounts.portfolio()
+    stats = dict(portfolio.percent.stats()[0])
+    
+    app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+    
+    text_1 = f"""
+    # Systematic Backtest
+    
+    This is a systematic backtest document to display the process used to make a rule based system.
+
+    ## Summary
+    The trading system has the following performance indicators:
+    - Name: {cfg.name}
+    - Vol target: {cfg.percentage_vol_target} %
+    - Notional trading capital: {cfg.notional_trading_capital}
+    - Base Currency: {cfg.base_currency}
+    - Rules: {cfg.rule_variations}
+    - Instruments: {cfg.instruments}
+    
+    The backtest has the following performance:
+    - Worst year: {stats['min']} %
+    - Best year: {stats['max']} %
+    - Median: {stats['median']} %
+    - Mean: {stats['mean']} %
+    - Std: {stats['std']} %
+    - Skew: {stats['skew']} %
+    - Annualized mean: {stats['ann_mean']} %
+    - Annualized standard Deviation: {stats['ann_std']} %
+    - Sharpe: {stats['sharpe']}
+    - Sortino ratio: {stats['sortino']}
+    - Average drawdown: {stats['avg_drawdown']} %
+    - Time in drawdown: {stats['time_in_drawdown']} years
+    - Calmar: {stats['calmar']}
+    - Average return to drawdown: {stats['avg_return_to_drawdown']} %
+    - Average loss: {stats['avg_loss']} %
+    - Average gain: {stats['avg_gain']} %
+    - Gain to loss ratio: {stats['gaintolossratio']}
+    - Profit factor: {stats['profitfactor']}
+    - Hit rate: {stats['hitrate']}
+    - t-statistic: {stats['t_stat']}
+    - p-value: {stats['p_value']}
+
+    ## Instruments
+    
+    The following instruments are used in this back-test
+    """
+    
+    # Price dropdown plot
+    @app.callback(
+        Output(f"prices-plot", "figure"), 
+        Input("price-ticker", "value"))
+    def display_price_time_series(ticker):
+        df = dfs["prices"] # replace with your own data source
+        fig = px.line(df, y=ticker)
+        fig = FigureResampler(fig)
+        fig.update_layout(
+            xaxis_title = 'Date',
+            yaxis_title = 'Price'
+        )
+        # fig.update_xaxes(
+        #     dtick="M3",
+        #     tickformat="%Y"
+        # )
+        return fig
+    
+    text_2 = """
+    
+    ## Trading Rules and Forecasts
+    
+    The combined performance of each rule is based upon the diversification and forecast weights. The following is used here:
+    - 1. Each rule's performance is back-tested on each instrument.
+    - 2. Each forecast is scaled and capped based on turnover and cost
+    - 3. Forecast weights are applied to each rule and instrument to maximize diversification. 
+    - 4. The combined forecast is the position in each asset after applying weights and rescaling to a [-20, +20] range.
+    
+    """
+    
+    # Raw Forecast plot
+    @app.callback(
+        Output("raw_forecasts-plot", "figure"),
+        [Input("raw_forecast-instrument", "value"),
+         Input("raw_forecast-rule", "value")]
+    )
+    def display_raw_forecast(instrument, rule):
+        df = dfs["raw_forecasts"][instrument]
+        fig = px.line(df, y=rule)
+        fig = FigureResampler(fig)
+        fig.update_layout(
+            xaxis_title = 'Date',
+            yaxis_title = 'Return'
+        ) 
+        return fig
+    
+    # Make a markdown table of forecast scalars for rules and instruments 
+    scalar_table = "| Instrument |"
+    for rule in rule_list:
+        scalar_table += f"{rule} |"
+    scalar_table += "\n"
+    for instrument in instruments:
+        rule_substring= "| "
+        rule_substring += f"**{instrument}** |"
+        for rule in rule_list:
+            rule_substring += f"{dfs['forecast_scalars'][instrument][rule]:.3f} |" 
+        rule_substring += "\n"
+        scalar_table += rule_substring
+    scalar_table = scalar_table.split("\n", 1)
+    seperator = "\n|"
+    seperator += "---|"
+    seperator += "\n"
+    scalar_table = scalar_table[0] + seperator + scalar_table[1]
+    
+    # Make a markdown table of turnover for rules and instruments 
+    turnover_table = "| Instrument |"
+    for rule in rule_list:
+        turnover_table += f"{rule} |"
+    turnover_table += "\n"
+    for instrument in instruments:
+        rule_substring= "| "
+        rule_substring += f"**{instrument}** |"
+        for rule in rule_list:
+            rule_substring += f"{dfs['forecast_turnovers'][instrument][rule]:.3f} |" 
+        rule_substring += "\n"
+        turnover_table += rule_substring
+    turnover_table = turnover_table.split("\n", 1)
+    seperator = "\n|"
+    seperator += "---|"
+    seperator += "\n"
+    turnover_table = turnover_table[0] + seperator + turnover_table[1]
+    
+    # Rule Weight plot
+    @app.callback(
+        Output("rule_weights-plot", "figure"), 
+        Input("weight-ticker", "value"))
+    def display_rule_weights_time_series(ticker):
+        df = dfs["rule_weights"] # replace with your own data source
+        tick_data = df[ticker]
+        fig = px.line(tick_data)
+        fig = FigureResampler(fig)
+        fig.update_layout(
+            xaxis_title = 'Date',
+            yaxis_title = 'Weight [-]'
+        )
+        return fig
+    
+    # Rule Correlations heatmap
+    @app.callback(
+        Output("rule_correlations-heatmap", "figure"),
+        Input("correlation-ticker", "value")
+    )
+    def display_rule_correlation_heatmap(instrument):
+        df = dfs["correlation"]
+        c_data = df[instrument]
+        fig = px.imshow(c_data, color_continuous_scale='Turbo')
+        fig.update_layout(template="ggplot2")
+        return fig
+        
+        
+    # Diversification plot
+    df = dfs["diversification"] # replace with your own data source
+    diversification_plot = px.line(df)
+    diversification_plot = FigureResampler(diversification_plot)
+    diversification_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'IDF [-]'
+    )
+    
+    # Combined Forecast plot
+    @app.callback(
+        Output("comb_forecasts-plot", "figure"), 
+        Input("forecast-ticker", "value"))
+    def display_comb_forecasts_time_series(ticker):
+        df = dfs["comb_forecasts"] # replace with your own data source
+        fig = px.line(df, y=ticker)
+        fig = FigureResampler(fig)
+        fig.update_layout(
+            xaxis_title = 'Date',
+            yaxis_title = 'Vol',
+        )
+        return fig
+    
+    text_3 = f"""
+    
+    ## Position Sizing and Portfolio
+    
+    The size of each position depends on the volatility and forecast from the last section:
+    - Instrument position is the capital if all capital was invested into the specific instrument
+    - Notional position is the actual capital from the rule
+    
+    """
+    
+    # Position plot
+    df = dfs["position"]
+    position_plot = px.line(df)
+    position_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'Position'
+    )
+    
+    # Notional plot
+    df = dfs["notional"]
+    notional_plot = px.line(df)
+    notional_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'Notional'
+    )
+    
+    text_4 = f"""
+    
+    # Performance
+    
+    The performance of the portfolio is displayed as:
+    - Accumulated Returns
+    - Rolling annualized standard deviation
+    - Drawdown
+    
+    """
+    
+    # Returns
+    df = dfs["accumulated_returns"]
+    returns_plot = px.line(df)
+    returns_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'Returns [%]',
+        showlegend = False
+    )
+    
+    # Ann_SD
+    df = dfs["annualized_volatility"]
+    annualized_volatility_plot = px.line(df)
+    annualized_volatility_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'Annualized Vol [%]',
+        showlegend = False
+    )
+    
+    # Drawdown
+    df = dfs["drawdown"]
+    drawdown_plot = px.line(df)
+    drawdown_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'Drawdown [%]',
+        showlegend = False
+    )
+    
+    SIDEBAR_STYLE = {
+        "position": "fixed",
+        "top": 0,
+        "left": 0,
+        "bottom": 0,
+        "width": "16rem",
+        "padding": "2rem 1rem",
+        "background-color": "#f8f9fa",
+    }
+    
+    CONTENT_STYLE = {
+        "margin-left": "18rem",
+        "margin-right": "2rem",
+        "padding": "2rem 1rem",
+    }
+    
+    sidebar = html.Div(
+        [
+            html.H2("Backtest", className="display-4"),
+            html.Hr(),
+            html.P(
+                "Stages of Backtest", className="lead"
+            ),
+            dbc.Nav(
+                [
+                    dbc.NavLink("Summary", href="/", active="exact"),
+                    dbc.NavLink("Instruments", href="/instruments", active="exact"),
+                    dbc.NavLink("Rules and Forecasts", href="/rules", active="exact"),
+                    dbc.NavLink("Position Sizing", href="/sizing", active="exact"),
+                    dbc.NavLink("Performance", href="/performance", active="exact"),
+                ],
+                vertical=True,
+                pills=True,
+            ),
+        ],
+        style=SIDEBAR_STYLE
+    )
+    
+    content = html.Div(id="page-content", style=CONTENT_STYLE)
+    app.layout = html.Div([dcc.Location(id="url"), sidebar, content])
+    
+    @app.callback(Output("page-content", "children"), [Input("url", "pathname")])
+    def render_page_content(pathname):
+        if pathname == "/":
+            return summary_content
+        elif pathname == "/instruments":
+            return instrument_content
+        elif pathname == "/rules":
+            return rule_content
+        elif pathname == "/sizing":
+            return sizing_content
+        elif pathname == "/performance":
+            return performance_content
+        else:
+            html.Div(
+                [
+                    html.H1("404: Not Found", className="text-danger"),
+                    html.Hr(),
+                    html.P(f"The pathname {pathname} was not recognized..."),  
+                ],
+                className="p-3 bg-light rounded-3",
+            )
+    
+    summary_content = dbc.Container([
+        dbc.Row([
+            dbc.Col(dcc.Markdown(text_1))
+        ])])
+    
+    instrument_content = dbc.Container([
+        dbc.Row([
+            html.H4("Instrument Prices"),
+            dcc.Graph(id="prices-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="price-ticker",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            ),
+        ])
+    ])
+    
+    rule_content = dbc.Container([
+        dbc.Row([
+            dbc.Col(dcc.Markdown(text_2))
+        ]),
+        
+        dbc.Row([
+            html.H4("Raw Forecasts"),
+            dcc.Graph(id="raw_forecasts-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="raw_forecast-instrument",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            ),
+            html.Br(),
+            html.P("Select rule:"),
+            dcc.Dropdown(
+                id="raw_forecast-rule",
+                options=rule_list,
+                value=rule_list[0],
+                clearable=False
+            )
+        ]),
+        dbc.Row([
+            dbc.Col(dcc.Markdown("Scalar forecast for each rule and instrument"))
+        ]),
+        dbc.Row([
+            dbc.Col(dcc.Markdown(scalar_table))
+        ]),
+        dbc.Row([
+            dbc.Col(dcc.Markdown("SR cost for each instrument and rule"))
+        ]),
+        dbc.Row([
+            dbc.Col(dcc.Markdown(turnover_table))
+        ]),
+        dbc.Row([
+            html.H4("Rule Weights"),
+            dcc.Graph(id="rule_weights-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="weight-ticker",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            ),
+        ]),
+        dbc.Row([
+            html.H4("Rule Correlation"),
+            dcc.Graph(id="rule_correlations-heatmap"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="correlation-ticker",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            ),
+        ]),
+        dbc.Row([
+            html.H4("Diversification"),
+            dcc.Graph(figure=diversification_plot)
+        ]),
+        dbc.Row([
+            dbc.Col(dcc.Markdown("""Rule weights and diversification multiplier is used to calculate the combined forecast below"""))
+        ]),
+        dbc.Row([
+            html.H4("Combined Forecasts"),
+            dcc.Graph(id="comb_forecasts-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="forecast-ticker",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            ),
+        ])
+    ])
+    
+    sizing_content = dbc.Container([
+        dbc.Row([
+            dbc.Col(dcc.Markdown(text_3))
+        ]),
+        dbc.Row([
+            html.H4("Instrument Position"),
+            dcc.Graph(figure=position_plot)
+        ]),
+        dbc.Row([
+            html.H4("Notional Position"),
+            dcc.Graph(figure=notional_plot)
+        ])
+    ])
+    
+    performance_content = dbc.Container([
+        dbc.Row([
+            dbc.Col(dcc.Markdown(text_4))
+        ]), 
+        dbc.Row([
+            html.H4("Accumulated Returns"),
+            dcc.Graph(figure=returns_plot)
+        ]),
+        dbc.Row([
+            html.H4("Rolling annualized standard deviation"),
+            dcc.Graph(figure=annualized_volatility_plot)  
+        ]),
+        dbc.Row([
+            html.H4("Drawdown"),
+            dcc.Graph(figure=drawdown_plot)
+        ])
+    ])
+    # app.title = cfg.app.title
+    app.run_server(host='0.0.0.0', port=8050)
+
+
+if __name__=="__main__":
+    run_app()

--- a/examples/visualize/dashviewer.py
+++ b/examples/visualize/dashviewer.py
@@ -1,0 +1,655 @@
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly_resampler import FigureResampler, FigureWidgetResampler
+from plotly.subplots import make_subplots
+from omegaconf import DictConfig, OmegaConf
+from pathlib import Path
+from dash import Dash, dcc, html, Input, Output
+import dash_bootstrap_components as dbc
+import hydra
+
+from sysdata.config.configdata import Config
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
+from systems.forecasting import Rules
+from systems.basesystem import System
+from systems.forecast_combine import ForecastCombine
+from systems.provided.attenuate_vol.vol_attenuation_forecast_scale_cap import volAttenForecastScaleCap
+from systems.provided.rob_system.rawdata import myFuturesRawData
+from systems.positionsizing import PositionSizing
+from systems.portfolio import Portfolios
+from systems.provided.dynamic_small_system_optimise.optimised_positions_stage import optimisedPositions
+from systems.risk import Risk
+from systems.accounts.accounts_stage import Account
+from systems.provided.dynamic_small_system_optimise.accounts_stage import accountForOptimisedStage
+
+
+class AppData:
+    
+    def __init__(self, cfg):
+        
+        # Setup dir and configs
+        self.work_dir = Path.cwd()
+        self.cfg = cfg
+
+        
+        # Make system and load data
+        rules_config = OmegaConf.to_container(self.cfg.trading_rules)
+        rules = Rules(rules_config)
+        data = csvFuturesSimData()
+        dict_config = OmegaConf.to_container(self.cfg)
+        config = Config(dict_config)
+
+        self.system = System(
+            [
+                Risk(),
+                accountForOptimisedStage(),
+                optimisedPositions(),
+                Portfolios(),
+                PositionSizing(),
+                myFuturesRawData(),
+                ForecastCombine(),
+                volAttenForecastScaleCap(),
+                rules,
+            ],
+            data,
+            config,
+        )
+        
+        if self.cfg.load_model:
+            print(f"Loading pickled model from {self.cfg.model_loc}")
+            self.system.cache.unpickle(f"{self.cfg.model_loc}.pck")
+        
+        if self.cfg.save_model:
+            print(f"Are we caching?: {self.system.cache.are_we_caching()}")
+        
+    def get_data(self) -> dict:
+        
+        """
+        Return data used to make dash page
+        """
+        
+        data = {}
+        self.system.accounts.portfolio().sharpe()
+        instruments = self.system.get_instrument_list()
+        rule_list = list(self.cfg.trading_rules.keys())
+        to_dataframe = lambda x: pd.concat(x.values(), axis=1, keys=x.keys(), join="outer")
+        
+        price_dict = {}
+        raw_forecast_dict = {}
+        position_dict = {}
+        correlation_dict = {}
+        rule_weight_dict = {}
+        diversification_dict = {}
+        comb_forecasts_dict = {}
+        
+        forecast_scalar_dict = {}
+        forecast_turnover_dict = {}
+
+        
+        for instrument in instruments:
+            
+            price_dict[instrument] = self.system.data.get_raw_price(instrument)
+            
+            raw_rule_forecast_dict = {}
+            forecast_scalar_dict = {}
+            forecast_turnover_dict = {}
+            
+            for rule in rule_list:
+                raw_rule_forecast_dict[rule] = self.system.rules.get_raw_forecast(instrument, rule)
+                forecast_scalar_dict[rule] = self.system.forecastScaleCap.get_forecast_scalar(instrument, rule).tail(1).iloc[0].item()
+                forecast_turnover_dict[rule] = self.system.accounts.get_SR_cost_for_instrument_forecast(instrument, rule).item()    
+            raw_forecast_dict[instrument] = raw_rule_forecast_dict
+            forecast_scalar_dict[instrument] = forecast_scalar_dict.copy()
+            forecast_turnover_dict[instrument] = forecast_scalar_dict.copy()
+
+            correlation_dict[instrument] = self.system.combForecast.get_forecast_correlation_matrices(instrument).corr_list[-1].as_pd()
+            rule_weight_dict[instrument] = self.system.combForecast.get_forecast_weights(instrument)
+            diversification_dict[instrument] = self.system.combForecast.get_forecast_diversification_multiplier(instrument)
+            comb_forecasts_dict[instrument] = self.system.combForecast.get_combined_forecast(instrument) 
+            
+            position_dict[instrument] = self.system.accounts.get_actual_position(instrument)
+        
+        # Instruments
+        price_df = to_dataframe(price_dict)
+        data["prices"] = price_df
+        
+        # Rules and weights
+        data["raw_forecast"] = raw_forecast_dict
+        data["forecast_scalars"] = forecast_scalar_dict
+        data["forecast_turnovers"] = forecast_turnover_dict
+        
+        data["correlation"] = correlation_dict
+        rule_weight_df = to_dataframe(rule_weight_dict)
+        data["rule_weights"] = rule_weight_df
+        diversification_df = to_dataframe(diversification_dict)
+        data["diversification"] = diversification_df
+        comb_forecasts_df = to_dataframe(comb_forecasts_dict)
+        data["comb_forecasts"] = comb_forecasts_df
+        
+        # Positions
+        position_df = to_dataframe(position_dict)
+        data["positions"] = position_df
+        
+        # Portfolio performance
+        portfolio = self.system.accounts.portfolio()
+        data["accumulated_returns"] = portfolio.percent.gross.curve()
+        data["drawdown"] = portfolio.percent.drawdown()
+        data["annualized_volatility"] = portfolio.percent.rolling_ann_std()
+        
+        # Save model
+        if self.cfg.save_model:
+            self.system.cache.pickle(f"{self.cfg.model_loc}.pck")
+        
+        return data
+
+
+@hydra.main(config_path='pysystemtrade/examples/visualize/configs/.', config_name='futures_system')
+def run_app(cfg):
+    
+    app_data = AppData(cfg)
+    data = app_data.get_data()
+    instruments = app_data.system.get_instrument_list()
+    rule_list = list(cfg.trading_rules.keys())
+    portfolio = app_data.system.accounts.portfolio()
+    stats = dict(portfolio.percent.stats()[0])
+    
+    app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+    
+    ############------------ Instruments ------------############
+    
+    # Price dropdown plot
+    @app.callback(
+        Output(f"prices-plot", "figure"), 
+        Input("price-instrument", "value"))
+    def display_price_time_series(instrument):
+        df = data["prices"][instrument].dropna() # replace with your own data source
+        fig = go.Figure()
+        fig.add_trace(
+            go.Scatter(
+                x=df.index,
+                y=df,
+                marker=dict(color='blue')
+            )
+        )
+        fig = FigureResampler(fig)
+        fig.update_layout(
+            xaxis_title='Date',
+            yaxis_title='Price',
+            template='plotly_white'
+        )
+        fig = FigureResampler(fig)
+        return fig
+    
+    ############------------ Rules and Forecasts ------------############
+    
+    # Raw Forecast plot
+    @app.callback(
+        Output("raw_forecasts-plot", "figure"),
+        [Input("raw_forecast-instrument", "value"),
+         Input("raw_forecast-rule", "value")]
+    )
+    def display_raw_forecast(instrument, rule):
+        df = data["raw_forecast"][instrument][rule]
+        fig = go.Figure()
+        fig.add_trace(
+            go.Scatter(
+                x=df.index,
+                y=df,
+                marker=dict(color='blue')
+            )
+        )
+        fig = FigureResampler(fig)
+        fig.update_layout(
+            xaxis_title = 'Date',
+            yaxis_title = 'Return',
+            template='plotly_white'
+        ) 
+        return fig
+    
+    # print(data["forecast_scalars"])
+    # print(data["forecast_turnovers"])
+    
+    # Rule Weights plot
+    @app.callback(
+        Output("rule_weights-plot", "figure"),
+        Input("weight-ticker", "value")
+    )
+    def display_rule_weights_time_series(instrument):
+        df = data["rule_weights"][instrument]
+        df = df.dropna()
+        fig = go.Figure()
+        for rule in df.keys():
+            fig.add_trace(
+                go.Scatter(
+                    x=df[rule].index,
+                    y=df[rule],
+                    mode='lines',
+                    name=rule
+                )
+            )
+            
+        fig.update_layout(
+            xaxis_title = 'Date',
+            yaxis_title = 'Weight',
+            template = 'plotly_white'
+        )
+        return fig
+    
+    # Rule Correlations heatmap
+    @app.callback(
+        Output("rule_correlations-heatmap", "figure"),
+        Input("correlation-ticker", "value")
+    )
+    def display_rule_correlation_heatmap(instrument):
+        df = data["correlation"]
+        c_data = df[instrument]
+        fig = px.imshow(c_data, color_continuous_scale='Turbo')
+        fig.update_layout(template="ggplot2")
+        return fig
+    
+    # Diversification plot
+    diversification_plot = go.Figure()
+    diversification_df = data["diversification"]
+    for instrument in instruments:
+        diversification_plot.add_trace(
+            go.Scatter(
+                x=diversification_df.index,
+                y=diversification_df[instrument],
+                mode='lines',
+                name=instrument
+            )
+        )
+    diversification_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'IDF [-]',
+        template='plotly_white'
+    )
+    # diversification_plot = FigureResampler(diversification_plot)
+    
+    # Combined Forecast plot
+    @app.callback(
+        Output("comb_forecasts-plot", "figure"),
+        Input("forecast-ticker", "value")
+    )
+    def display_comb_forecasts_time_series(instrument):
+        df = data["comb_forecasts"][instrument]
+        df = df.dropna()
+        fig = go.Figure()
+        fig.add_trace(
+            go.Scatter(
+                x=df.index,
+                y=df,
+                marker=dict(color='black')
+            )
+        )
+        fig = FigureResampler(fig)
+        fig.update_layout(
+            xaxis_title='Date',
+            yaxis_title='Level',
+            template='plotly_white'
+        )
+        fig = FigureResampler(fig)
+        return fig
+        
+    
+    ############------------ Position Sizing ------------############
+    # Price dropdown plot
+    @app.callback(
+        Output(f"positions-plot", "figure"), 
+        Input("position-instrument", "value"))
+    def display_position_time_series(instrument):
+        position_df = data["positions"][instrument].dropna()
+        price_df = data["prices"][instrument].dropna()
+        price_df.index = price_df.index.date
+        merged_df = pd.merge(price_df.rename('price'), position_df.rename('position'), left_index=True, right_index=True, how='left')
+        # merged_df['position'] = merged_df['position'].fillna(method='ffill')
+        merged_df['buy_signal'] = (merged_df['position'].shift(1) <= 1.0) & (merged_df['position'] > 1.0)
+        merged_df['sell_signal'] = (merged_df['position'].shift(1) > -1.0) & (merged_df['position'] <= -1.0)
+        
+        fig = make_subplots(
+            rows=2, cols=1,
+            # subplot_titles=('Prices', 'Positions'),
+            row_heights=[0.7, 0.3],
+            shared_xaxes=True
+        )
+        
+        fig.add_trace(
+            go.Scatter(
+                x=merged_df.index, 
+                y=merged_df['price'], 
+                mode='lines', 
+                name='Price', 
+                marker=dict(color='black')
+            ),
+            row=1,
+            col=1
+        )
+        
+        fig.add_trace(
+            go.Scatter(
+                x=merged_df.index[merged_df['buy_signal']],
+                y=merged_df['price'][merged_df['buy_signal']],
+                mode='markers',
+                marker=dict(symbol='triangle-up', color='green', size=10),
+                name='Buy Signal'
+            ),
+            row=1,
+            col=1
+        )
+        
+        fig.add_trace(
+            go.Scatter(
+                x=merged_df.index[merged_df['sell_signal']],
+                y=merged_df['price'][merged_df['sell_signal']],
+                mode='markers',
+                marker=dict(symbol='triangle-down', color='red', size=10),
+                name='Sell Signal'
+            ),
+            row=1,
+            col=1
+        )
+        
+        fig.add_trace(
+            go.Scatter(
+                x=position_df.index,
+                y=position_df,
+                mode='lines',
+                marker=dict(color='grey'),
+                name='Position'
+            ),
+            row=2,
+            col=1
+        )
+        
+        fig.update_layout(
+            xaxis_title='Date',
+            yaxis_title='Price',
+            template='plotly_white'
+        )
+        fig = FigureResampler(fig)
+        return fig
+    
+    ############------------ Performance ------------############
+    
+    # Accumulated returns
+    returns_plot = go.Figure()
+    returns_df = data["accumulated_returns"]
+    returns_plot.add_trace(
+        go.Scatter(
+            x=returns_df.index, 
+            y=returns_df, 
+            mode='lines',
+            marker=dict(color='black')
+        )
+    )
+    returns_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'Returns [%]',
+        showlegend = False,
+        template='plotly_white'
+    )
+    
+    # Rolling annualized standard deviation
+    annualized_volatility_plot = go.Figure()
+    vol_df = data["annualized_volatility"]
+    annualized_volatility_plot.add_trace(
+        go.Scatter(
+            x=vol_df.index,
+            y=vol_df[0],
+            mode='lines',
+            marker=dict(color='black')
+        )
+    )
+    annualized_volatility_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'Annualized Vol [%]',
+        showlegend = False,
+        template='plotly_white'
+    )
+    
+    # Drawdown
+    drawdown_plot = go.Figure()
+    drawdown_df = data["drawdown"]
+    drawdown_plot.add_trace(
+        go.Scatter(
+            x=drawdown_df.index,
+            y=drawdown_df,
+            mode='lines',
+            marker=dict(color='black')
+        )
+    )
+    drawdown_plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = 'Drawdown [%]',
+        showlegend = False,
+        template='plotly_white'
+    )
+    
+    SIDEBAR_STYLE = {
+        "position": "fixed",
+        "top": 0,
+        "left": 0,
+        "bottom": 0,
+        "width": "16rem",
+        "padding": "2rem 1rem",
+        "background-color": "#f8f9fa",
+    }
+    
+    CONTENT_STYLE = {
+        "margin-left": "18rem",
+        "margin-right": "2rem",
+        "padding": "2rem 1rem",
+    }
+    
+    sidebar = html.Div(
+        [
+            html.H2("Backtest", className="display-4"),
+            html.Hr(),
+            html.P(
+                "Stages of Backtest", className="lead"
+            ),
+            dbc.Nav(
+                [
+                    dbc.NavLink("Summary", href="/", active="exact"),
+                    dbc.NavLink("Instruments", href="/instruments", active="exact"),
+                    dbc.NavLink("Rules and Forecasts", href="/rules", active="exact"),
+                    dbc.NavLink("Position Sizing", href="/sizing", active="exact"),
+                    dbc.NavLine("Risk", href="/risk", active="exact"),
+                    dbc.NavLink("Performance", href="/performance", active="exact"),
+                ],
+                vertical=True,
+                pills=True,
+            ),
+        ],
+        style=SIDEBAR_STYLE
+    )
+    
+    content = html.Div(id="page-content", style=CONTENT_STYLE)
+    app.layout = html.Div([dcc.Location(id="url"), sidebar, content])
+    
+    @app.callback(Output("page-content", "children"), [Input("url", "pathname")])
+    def render_page_content(pathname):
+        if pathname == "/":
+            return summary_content
+        elif pathname == "/instruments":
+            return instrument_content
+        elif pathname == "/rules":
+            return rules_content
+        elif pathname == "/sizing":
+            return sizing_content
+        elif pathname == "/risk":
+            return None
+        elif pathname == "/performance":
+            return performance_content
+        else: 
+            html.Div(
+                [
+                    html.H1("404: Not Found", className="text-danger"),
+                    html.Hr(),
+                    html.P(f"The pathname {pathname} was not recognized..."),  
+                ],
+                className="p-3 bg-light rounded-3",
+            )
+    
+    summary_content = dbc.Container([
+        dbc.Row([
+            dcc.Markdown(
+                f"""
+                
+                # Summary
+                
+                This is a backtest of a systematic trading system with the following parameters:
+                - Name: {cfg.name}
+                - Vol target: {cfg.percentage_vol_target} %
+                - Notional trading capital: {cfg.notional_trading_capital}
+                - Base Currency: {cfg.base_currency}
+                - Rules: {cfg.trading_rules.keys()}
+                - Instruments: {instruments}
+                
+                In a backtest this system achieves the following performance:
+                - Worst year: {stats['min']} %
+                - Best year: {stats['max']} %
+                - Median: {stats['median']} %
+                - Mean: {stats['mean']} %
+                - Std: {stats['std']} %
+                - Skew: {stats['skew']} %
+                - Annualized mean: {stats['ann_mean']} %
+                - Annualized standard Deviation: {stats['ann_std']} %
+                - Sharpe: {stats['sharpe']}
+                - Sortino ratio: {stats['sortino']}
+                - Average drawdown: {stats['avg_drawdown']} %
+                - Time in drawdown: {stats['time_in_drawdown']} years
+                - Calmar: {stats['calmar']}
+                - Average return to drawdown: {stats['avg_return_to_drawdown']} %
+                - Average loss: {stats['avg_loss']} %
+                - Average gain: {stats['avg_gain']} %
+                - Gain to loss ratio: {stats['gaintolossratio']}
+                - Profit factor: {stats['profitfactor']}
+                - Hit rate: {stats['hitrate']}
+                - t-statistic: {stats['t_stat']}
+                - p-value: {stats['p_value']}
+                
+                """
+            )
+        ]),
+    ])
+    
+    instrument_content = dbc.Container([
+        dbc.Row([
+            dcc.Markdown("Futures Contract instruments for each asset considered")
+        ]),
+        dbc.Row([
+            html.H4("Instrument Prices"),
+            dcc.Graph(id="prices-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="price-instrument",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            )
+        ]),
+    ])
+    
+    rules_content = dbc.Container([
+        
+        dbc.Row([
+            html.H4("Raw Forecast"),
+            dcc.Graph(id="raw_forecasts-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="raw_forecast-instrument",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            ),
+            html.Br(),
+            html.P("Select rule:"),
+            dcc.Dropdown(
+                id="raw_forecast-rule",
+                options=rule_list,
+                value=rule_list[0],
+                clearable=False
+            ), 
+        ]),
+        
+        dbc.Row([
+            html.H4("Rule Weights"),
+            dcc.Graph(id="rule_weights-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="weight-ticker",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            )
+        ]),
+        dbc.Row([
+            html.H4("Rule Correlation"),
+            dcc.Graph(id="rule_correlations-heatmap"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="correlation-ticker",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            )
+        ]),
+        dbc.Row([
+            html.H4("Diversification"),
+            dcc.Graph(figure=diversification_plot)
+        ]),
+        dbc.Row([
+            html.H4("Combined Forecasts"),
+            dcc.Graph(id="comb_forecasts-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="forecast-ticker",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            )
+        ])
+    ])
+    
+    sizing_content = dbc.Container([
+        dbc.Row([
+            dcc.Markdown("Positions actually held and in which size")
+        ]),
+        dbc.Row([
+            html.H4("Position Plots"),
+            dcc.Graph(id="positions-plot"),
+            html.P("Select instrument:"),
+            dcc.Dropdown(
+                id="position-instrument",
+                options=instruments,
+                value=instruments[0],
+                clearable=False
+            )
+        ])
+    ])
+    
+    performance_content = dbc.Container([
+        dbc.Row([
+            dbc.Col(dcc.Markdown("Plots comparing the performance of this trading system"))
+        ]),
+        dbc.Row([
+            html.H4("Accumulated Returns"),
+            dcc.Graph(figure=returns_plot)
+        ]),
+        dbc.Row([
+            html.H4("Rolling annualized standard deviation"),
+            dcc.Graph(figure=annualized_volatility_plot)
+        ]),
+        dbc.Row([
+            html.H4("Drawdown"),
+            dcc.Graph(figure=drawdown_plot)
+        ]),
+    ])
+    
+    app.run_server(host='0.0.0.0', port=8050)
+
+    
+if __name__=="__main__":
+    run_app()

--- a/examples/visualize/wandbtest.py
+++ b/examples/visualize/wandbtest.py
@@ -1,0 +1,195 @@
+import wandb
+import pandas as pd
+import plotly.express as px
+from omegaconf import DictConfig, OmegaConf
+from pathlib import Path
+import hydra
+
+from typing import List
+
+from sysdata.config.configdata import Config
+from sysdata.sim.csv_futures_sim_data import csvFuturesSimData
+from systems.forecasting import Rules
+from systems.basesystem import System
+from systems.forecast_combine import ForecastCombine
+from systems.forecast_scale_cap import ForecastScaleCap
+from systems.rawdata import RawData
+from systems.positionsizing import PositionSizing
+from systems.portfolio import Portfolios
+from systems.accounts.accounts_stage import Account
+
+def make_px_line_plot(data: pd.core.frame.DataFrame, title: str, yaxis_title: str):
+    
+    plot = px.line(data, title=title)
+    plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = yaxis_title,
+        showlegend=False
+    )
+    
+    return plot
+
+def make_px_ncg_bar(data: pd.core.frame.DataFrame, title: str, yaxis_title: str):
+    
+    data['costs'] = 1.0 * data['costs']
+    plot = px.bar(data, y=["gross", "costs"], title=title)
+    plot.update_layout(
+        xaxis_title = 'Date',
+        yaxis_title = yaxis_title,
+        showlegend=False
+    )
+    
+    return plot
+
+class Workspace:
+    
+    def __init__(self, cfg):
+        
+        # Setup dir configs
+        self.work_dir = Path.cwd()
+        self.log_dir = cfg.log_dir
+        self.cfg = cfg
+
+        # Make system and load data
+        rules_config = OmegaConf.to_container(self.cfg.trading_rules)
+        rules = Rules(rules_config)
+        data = csvFuturesSimData()
+        dict_config = OmegaConf.to_container(self.cfg)
+        config = Config(dict_config)
+        
+        self.system = System(
+            [
+                Account(),
+                Portfolios(),
+                PositionSizing(),
+                RawData(),
+                ForecastCombine(),
+                ForecastScaleCap(),
+                rules,
+            ],
+            data,
+            config
+        )
+        
+        if self.cfg.use_wandb:
+            wandb.init(
+                project="SystemTrade",
+                name="server/system-test",
+                config=self.system.config.as_dict()
+            )
+        
+    def backtest(self):
+        
+        # -- Breakdown of portfolio --
+        
+        # Forecast Variability
+        comb_forecasts = {}
+        for instrument in self.system.get_instrument_list():
+            comb_forecasts[instrument] = self.system.combForecast.get_combined_forecast(instrument)
+        comb_forecasts_df = pd.concat(comb_forecasts.values(), axis=1, keys=comb_forecasts.keys(), join='inner')
+        comb_forecast_plot = make_px_line_plot(data=comb_forecasts_df, title='Combined Expected Variability', yaxis_title='Variability [-]')
+        if self.cfg.use_wandb:
+            wandb.log({"forecast/comb_forecast": wandb.Plotly(comb_forecast_plot)})
+        
+        
+        # -- Volatility targeting --
+        # Rule weight estimates
+        for instrument in self.system.get_instrument_list():
+            rule_weights = self.system.combForecast.get_forecast_weights(instrument)
+            weights_plot = make_px_line_plot(data=rule_weights, title=f'{instrument} Rule Weights', yaxis_title='Weight Fraction [-]')
+            if self.cfg.use_wandb:
+                wandb.log({"forecast/rule_weights": wandb.Plotly(weights_plot)}) 
+            
+        # Instrument diversification estimates
+        diversification = {}
+        for instrument in self.system.get_instrument_list():
+            rule_weights = self.system.combForecast.get_forecast_diversification_multiplier(instrument)
+            diversification[instrument] = rule_weights
+        diversification_df = pd.concat(diversification.values(), axis=1, keys=diversification.keys(), join = 'inner')
+        diversification_plot = make_px_line_plot(diversification_df, title='Instrument Diversification', yaxis_title='IDF [-]')
+        if self.cfg.use_wandb:
+            wandb.log({"forecast/diversification": wandb.Plotly(diversification_plot)})
+        
+        # -- Position sizing --
+        # Size of each instrument
+        # Plot positions and notional 
+        
+        notional_positions = {}
+        position_sizes = {}
+        for instrument in self.system.get_instrument_list():
+            notional_positions[instrument] = self.system.portfolio.get_notional_position(instrument)
+            position_sizes[instrument] = self.system.positionSize.get_subsystem_position(instrument)
+
+        notional_df = pd.concat(notional_positions.values(), axis=1, keys=notional_positions.keys(), join = 'inner')
+        notional_plot = make_px_line_plot(data=notional_df, title='Notional Positions', yaxis_title='Notional Position [USD]')
+        if self.cfg.use_wandb:
+            wandb.log({"portfolio/notional_plot": wandb.Plotly(notional_plot)})
+        
+        position_df = pd.concat(position_sizes.values(), axis=1, keys=position_sizes.keys(), join = 'inner') 
+        position_plot = make_px_line_plot(data=position_df, title='Position for subsystem', yaxis_title='Position [USD]')
+        if self.cfg.use_wandb:
+            wandb.log({"portfolio/position_plot": wandb.Plotly(position_plot)})
+        
+        # Instrument weights
+        weights = self.system.accounts.instrument_weights()
+        weights_plot = make_px_line_plot(weights, title='System Weights', yaxis_title='[-]')
+        if self.cfg.use_wandb:
+            wandb.log({"portfolio/instrument_weights": wandb.Plotly(weights_plot)})
+        
+        # Rule weights
+        
+        # -- Generalized run performance --
+        # Summary statistics for portfolio
+        portfolio = self.system.accounts.portfolio()
+        summary_stats = portfolio.percent.stats()
+        for stat in summary_stats[0]:
+            if self.cfg.use_wandb:
+                wandb.run.summary[stat[0]] = stat[1]
+        
+        roll_ann_plot = make_px_line_plot(portfolio.percent.rolling_ann_std(), title='Rolling Annualized Volatility', yaxis_title='Vol [%]')
+        gross_plot = make_px_line_plot(portfolio.percent.gross.curve(), title='Gross', yaxis_title='Profit [%]')
+        drawdown_plot = make_px_line_plot(portfolio.percent.drawdown(), title='Drawdown', yaxis_title='Drawdown [%]')
+        
+        if self.cfg.use_wandb:
+            wandb.log({"portfolio/rolling_ann_std": wandb.Plotly(roll_ann_plot),
+                    "portfolio/accumulated_returns": wandb.Plotly(gross_plot),
+                    "portfolio/drawdown": wandb.Plotly(drawdown_plot)})
+        
+        # Log trading rule performance across all instruments
+        # What does each rule do in this portfolio?
+        rule_performance = self.system.accounts.pandl_for_all_trading_rules()
+        for key in self.system.config.trading_rules.keys():
+            ncg = rule_performance[key].percent.annual.to_ncg_frame()
+            ncg_plot = make_px_ncg_bar(ncg, title=key, yaxis_title='%')
+            if self.cfg.use_wandb:
+                wandb.log({f"rule/{key}": wandb.Plotly(ncg_plot)})
+        
+        # Log portfolio contribution of each instrument
+        # What does this instrument do?
+        for instrument in self.system.get_instrument_list():
+            price = self.system.data.get_raw_price(instrument)
+            price_plot = make_px_line_plot(price, title=f'{instrument}', yaxis_title='Price')
+            if self.cfg.use_wandb:
+                wandb.log({f"prices/{instrument}": wandb.Plotly(price_plot)})
+            acc_curve = self.system.accounts.pandl_for_instrument(instrument)
+            ncg = acc_curve.percent.annual.to_ncg_frame()
+            ncg_plot = make_px_ncg_bar(ncg, title='Net/Cost/Gross', yaxis_title='%')
+            if self.cfg.use_wandb:
+                wandb.log({f"instrument/{instrument}": wandb.Plotly(ncg_plot)})
+        
+        # Log isolated instrument/rules, mainly to understand what each rule is upto 
+        # How do each of the rules behave?
+        
+        if self.cfg.use_wandb:
+            wandb.finish()
+
+
+@hydra.main(config_path='pysystemtrade/examples/visualize/configs/.', config_name='system')
+def main(cfg):
+    from system.wandbtest import Workspace as W
+    workspace = W(cfg)
+    workspace.backtest()
+    
+
+if __name__=="__main__":
+    main()


### PR DESCRIPTION
Added the visualize directory under examples/introduction
There are 3 runs to look at:

### dashviewer.py
This is the most recent work that shows how plotly can be used with the futures system, still have to add the risk module and dynamic optimization plots. These are mainly based on the plots shown in the blogs.

### dashtest.py
The first version of dash using the simple system from chapter 15

### wandbtest.py
A test to use wandb to track system changes, I don't think wandb timeseries display suits it that well to this task but its an easy way to quickly check system performance over various backtest hyper parameters.

- Requires:
  - [plotly](https://plotly.com)
  - [dash](https://plotly.com/dash/) 
  - [dash_bootstrap_componenents](https://dash-bootstrap-components.opensource.faculty.ai)
  - [hydra](https://hydra.cc/docs/intro/)
  - [wandb](https://wandb.ai/site) only for wandbtest.py