### PR TITLE
Bug 1428 ib critical errors

### DIFF
--- a/sysbrokers/IB/client/ib_client.py
+++ b/sysbrokers/IB/client/ib_client.py
@@ -130,7 +130,7 @@ class ibClient(object):
             self.broker_message(msg=msg, log=self.log)
 
     def broker_error(self, msg, log, myerror_type):
-        log.warning(msg)
+        log.critical(msg)
 
     def broker_message(self, log, msg):
         log.debug(msg)

--- a/sysbrokers/IB/client/ib_client.py
+++ b/sysbrokers/IB/client/ib_client.py
@@ -130,7 +130,7 @@ class ibClient(object):
             self.broker_message(msg=msg, log=self.log)
 
     def broker_error(self, msg, log, myerror_type):
-        log.critical(msg)
+        log.warning(msg)
 
     def broker_message(self, log, msg):
         log.debug(msg)

--- a/sysbrokers/IB/ib_connection.py
+++ b/sysbrokers/IB/ib_connection.py
@@ -69,7 +69,9 @@ class connectionIB(object):
             # Log all exceptions generated during connection as critical error.
             # Under the default production setup this should send an email.
             # Error is reraised as we can't really continue and user intervention is required
-            self.log.critical(f"IB connection falied with exception - {e}, connection aborted.")
+            self.log.critical(
+                f"IB connection falied with exception - {e}, connection aborted."
+            )
             raise
 
     def _init_connection(

--- a/sysbrokers/IB/ib_connection.py
+++ b/sysbrokers/IB/ib_connection.py
@@ -61,9 +61,16 @@ class connectionIB(object):
 
         # You can pass a client id yourself, or let IB find one
 
-        self._init_connection(
-            ipaddress=ipaddress, port=port, client_id=client_id, account=account
-        )
+        try:
+            self._init_connection(
+                ipaddress=ipaddress, port=port, client_id=client_id, account=account
+            )
+        except Exception as e:
+            # Log all exceptions generated during connection as critical error.
+            # Under the default production setup this should send an email.
+            # Error is reraised as we can't really continue and user intervention is required
+            self.log.critical(f"IB connection falied with exception - {e}, connection aborted.")
+            raise
 
     def _init_connection(
         self, ipaddress: str, port: int, client_id: int, account=arg_not_supplied


### PR DESCRIPTION
Amended IB connection method to catch all exceptions, log a critical error message and re-raise.
Changed ib_client.py error_handler to log all broker_errors as critical rather than as warnings.
