### PR TITLE
Fix for #1408

### DIFF
--- a/sysproduction/reporting/data/rolls.py
+++ b/sysproduction/reporting/data/rolls.py
@@ -458,8 +458,12 @@ def last_price_data_with_matched_contracts(df_of_col_and_col_to_use):
         ):
             row_to_copy = df_of_col_and_col_to_use[
                 ["Price_to_find", "Price_infer_from"]
-            ].iloc[data_row_idx]
-            matched_df_dict = matched_df_dict.append(row_to_copy)
+            ].iloc[[data_row_idx]]
+
+            if matched_df_dict.empty:
+                matched_df_dict = row_to_copy
+            else:
+                matched_df_dict = pd.concat([matched_df_dict, row_to_copy])
         else:
             # We're full
             break


### PR DESCRIPTION
Replaced DataFrame.append with DataFrame.concat, a df.empty check is not required but avoids the FutureWarning about dtype of an empty DataFrame in concat