### PR TITLE
fixes backtest crash when attempting to estimate weights for expensive instruments

### DIFF
--- a/systems/portfolio.py
+++ b/systems/portfolio.py
@@ -727,16 +727,20 @@ class Portfolios(SystemStage):
         instrument_list_to_add = (
             self.allocate_zero_instrument_weights_to_these_instruments()
         )
-        weight_index = instrument_weights.index
-        new_pd_as_dict = dict(
-            [
-                (instrument_code, pd.Series([0.0] * len(weight_index)))
-                for instrument_code in instrument_list_to_add
-            ]
-        )
-        new_pd = pd.DataFrame(new_pd_as_dict)
+        # weight_index = instrument_weights.index
+        # new_pd_as_dict = dict(
+        #     [
+        #         (instrument_code, pd.Series([0.0] * len(weight_index)))
+        #         for instrument_code in instrument_list_to_add
+        #     ]
+        # )
+        # new_pd = pd.DataFrame(new_pd_as_dict)
+        #
+        # padded_instrument_weights = pd.concat([instrument_weights, new_pd], axis=1)
 
-        padded_instrument_weights = pd.concat([instrument_weights, new_pd], axis=1)
+        padded_instrument_weights = copy(instrument_weights)
+        for zero_instr in instrument_list_to_add:
+            padded_instrument_weights[zero_instr] = 0.0
 
         return padded_instrument_weights
 


### PR DESCRIPTION
Proposed fix for #1482 

Scenario is you're running a backtest to estimate instrument weights, and attempting to exclude expensive instruments. So minimum working example to exhibit the problem:

```
from systems.provided.futures_chapter15.basesystem import futures_system
from sysdata.config.configdata import Config
from systems.trading_rules import TradingRule
from systems.provided.rules.ewmac import ewmac

my_config = Config(dict(
    start_date="2015-01-01",
    use_instrument_weight_estimates=True,
    forecast_post_ceiling_cost_SR=0.13,
    instruments=["CRUDE_W", "BUND", "GOLD", "NASDAQ", "NZD", "V2X"]
))

ewmac_16 = TradingRule(dict(function=ewmac, data=["rawdata.get_daily_prices",
                                                  "rawdata.daily_returns_volatility"],
                            other_args=dict(Lfast=16, Lslow=64)))
ewmac_32 = TradingRule(dict(function=ewmac, data=["rawdata.get_daily_prices",
                                                  "rawdata.daily_returns_volatility"],
                            other_args=dict(Lfast=32, Lslow=128)))

system = futures_system(config=my_config, trading_rules=[ewmac_16, ewmac_32])
system.accounts.portfolio()
```

It looks like the existing code in `systems.portfolio.py` lines 730 - 739 is supposed to create a new column series for the expensive instrument (V2X in the example) full of zeros, and append it to the dataframe of weights. But the datetime index does not get created properly, so the new column ends up adding a whole bunch of new rows, with integer keys instead of dates. That causes a crash later down the line when the weights df is used. 

My proposed solution (lines 741 - 743) uses a simpler method to add the column of zeros.

Could someone else review this and make sure I'm not missing anything, or doing something stupid? @tgibson11, @vishalg? @robcarver17 if you're around?
