### PR TITLE
include pyarrow in required dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "PyPDF2>=2.5.0",
     "scikit-learn>1.3.0",
     "pytz==2023.3",
+    "pyarrow>=16,<20",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
It's a little hard to know how to specify the versions. We want the latest, but probably not before a version is stable. Its a big project, and the python lib is a small part of it. They do seem to release quite frequently. But it looks like the internal format is [pretty stable](https://arrow.apache.org/docs/format/Versioning.html#forward-compatibility).

If anyone has any objections or ideas, please shout...