### PR TITLE
Suppress another pandas future warning

### DIFF
--- a/syscore/pandas/frequency.py
+++ b/syscore/pandas/frequency.py
@@ -114,9 +114,7 @@ def merge_data_with_different_freq(
 
     filtered = [item for item in list_of_data if len(item) > 0]
     if len(filtered) == 0:
-        return pd.DataFrame()
-    elif len(filtered) == 1:
-        list_as_concat_pd = filtered[0]
+        return list_of_data[0]
     else:
         list_as_concat_pd = pd.concat(filtered, axis=0)
     sorted_pd = list_as_concat_pd.sort_index()

--- a/syscore/pandas/frequency.py
+++ b/syscore/pandas/frequency.py
@@ -113,10 +113,12 @@ def merge_data_with_different_freq(
     """
 
     filtered = [item for item in list_of_data if len(item) > 0]
-    if len(filtered) > 1:
-        list_as_concat_pd = pd.concat(filtered, axis=0)
-    else:
+    if len(filtered) == 0:
+        return pd.DataFrame()
+    elif len(filtered) == 1:
         list_as_concat_pd = filtered[0]
+    else:
+        list_as_concat_pd = pd.concat(filtered, axis=0)
     sorted_pd = list_as_concat_pd.sort_index()
     unique_pd = uniquets(sorted_pd)
 

--- a/syscore/pandas/frequency.py
+++ b/syscore/pandas/frequency.py
@@ -112,10 +112,11 @@ def merge_data_with_different_freq(
     dtype: int64
     """
 
-    if len(list_of_data) > 1:
-        list_as_concat_pd = pd.concat(list_of_data, axis=0)
+    filtered = [item for item in list_of_data if len(item) > 0]
+    if len(filtered) > 1:
+        list_as_concat_pd = pd.concat(filtered, axis=0)
     else:
-        list_as_concat_pd = list_of_data[0]
+        list_as_concat_pd = filtered[0]
     sorted_pd = list_as_concat_pd.sort_index()
     unique_pd = uniquets(sorted_pd)
 

--- a/syscore/pandas/frequency.py
+++ b/syscore/pandas/frequency.py
@@ -112,7 +112,10 @@ def merge_data_with_different_freq(
     dtype: int64
     """
 
-    list_as_concat_pd = pd.concat(list_of_data, axis=0)
+    if len(list_of_data) > 1:
+        list_as_concat_pd = pd.concat(list_of_data, axis=0)
+    else:
+        list_as_concat_pd = list_of_data[0]
     sorted_pd = list_as_concat_pd.sort_index()
     unique_pd = uniquets(sorted_pd)
 

--- a/sysproduction/update_historical_prices.py
+++ b/sysproduction/update_historical_prices.py
@@ -492,9 +492,11 @@ def write_merged_prices_for_contract(
 
     merged_prices = merge_data_with_different_freq(list_of_data)
 
-    price_updater.overwrite_merged_prices_for_contract(
-        contract_object=contract_object, new_prices=futuresContractPrices(merged_prices)
-    )
+    if len(merged_prices) > 0:
+        price_updater.overwrite_merged_prices_for_contract(
+            contract_object=contract_object,
+            new_prices=futuresContractPrices(merged_prices),
+        )
 
 
 if __name__ == "__main__":

--- a/sysproduction/update_historical_prices.py
+++ b/sysproduction/update_historical_prices.py
@@ -482,19 +482,20 @@ def write_merged_prices_for_contract(
     diag_prices = diagPrices(data)
     price_updater = updatePrices(data)
 
-    list_of_data = [
-        diag_prices.get_prices_at_frequency_for_contract_object(
+    list_of_data = []
+    for frequency in list_of_frequencies:
+        prices = diag_prices.get_prices_at_frequency_for_contract_object(
             contract_object,
             frequency=frequency,
         )
-        for frequency in list_of_frequencies
-    ]
+        if len(prices) > 0:
+            list_of_data.append(prices)
 
-    merged_prices = merge_data_with_different_freq(list_of_data)
-
-    price_updater.overwrite_merged_prices_for_contract(
-        contract_object=contract_object, new_prices=merged_prices
-    )
+    if list_of_data:
+        merged_prices = merge_data_with_different_freq(list_of_data)
+        price_updater.overwrite_merged_prices_for_contract(
+            contract_object=contract_object, new_prices=merged_prices
+        )
 
 
 if __name__ == "__main__":

--- a/sysproduction/update_historical_prices.py
+++ b/sysproduction/update_historical_prices.py
@@ -482,20 +482,19 @@ def write_merged_prices_for_contract(
     diag_prices = diagPrices(data)
     price_updater = updatePrices(data)
 
-    list_of_data = []
-    for frequency in list_of_frequencies:
-        prices = diag_prices.get_prices_at_frequency_for_contract_object(
+    list_of_data = [
+        diag_prices.get_prices_at_frequency_for_contract_object(
             contract_object,
             frequency=frequency,
         )
-        if len(prices) > 0:
-            list_of_data.append(prices)
+        for frequency in list_of_frequencies
+    ]
 
-    if list_of_data:
-        merged_prices = merge_data_with_different_freq(list_of_data)
-        price_updater.overwrite_merged_prices_for_contract(
-            contract_object=contract_object, new_prices=merged_prices
-        )
+    merged_prices = merge_data_with_different_freq(list_of_data)
+
+    price_updater.overwrite_merged_prices_for_contract(
+        contract_object=contract_object, new_prices=futuresContractPrices(merged_prices)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Suppress another pandas FutureWarning: 

> FutureWarning: The behavior of array concatenation with empty entries is deprecated. In a future version, this will no longer exclude empty items when determining the result dtype. To retain the old behavior, exclude the empty entries before the concat operation.

pandas is now strict about guessing types when concatenating mixed dtypes. We avoid it here by only attempting to concatenate if the frames to be merged have lengths > 0