### PR TITLE
Replace 'EDOLLAR' with 'SOFR' in introduction.md

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,7 @@ data.get_instrument_list()
 ```
 
 ```
-['CORN', 'LEANHOG', 'LIVECOW', 'SOYBEAN', 'WHEAT', 'KR10', 'KR3', 'BOBL', 'BTP', 'BUND', 'OAT', 'SHATZ', 'US10', 'US2', 'US20', 'US5', 'V2X', 'VIX', 'KOSPI', 'AEX', 'CAC', 'SMI', 'NASDAQ', 'SP500', 'AUD', 'EUR', 'GBP', 'JPY', 'MXP', 'NZD', 'COPPER', 'GOLD', 'PALLAD', 'PLAT', 'CRUDE_W', 'GAS_US', 'EDOLLAR', 'EUROSTX']
+['CORN', 'LEANHOG', 'LIVECOW', 'SOYBEAN', 'WHEAT', 'KR10', 'KR3', 'BOBL', 'BTP', 'BUND', 'OAT', 'SHATZ', 'US10', 'US2', 'US20', 'US5', 'V2X', 'VIX', 'KOSPI', 'AEX', 'CAC', 'SMI', 'NASDAQ', 'SP500', 'AUD', 'EUR', 'GBP', 'JPY', 'MXP', 'NZD', 'COPPER', 'GOLD', 'PALLAD', 'PLAT', 'CRUDE_W', 'GAS_US', 'SOFR', 'EUROSTX']
 ```
 
 Not all the instruments are easily identifiable
@@ -42,7 +42,7 @@ futuresInstrumentWithMetaData(instrument=MUMMY, meta_data=instrumentMetaData(Des
 And what kind of data can we get for them?
 
 ```python
-data.get_raw_price("EDOLLAR").tail(5)
+data.get_raw_price("SOFR").tail(5)
 ```
 
 ```
@@ -68,7 +68,7 @@ data['SP500_micro'] ## equivalent to data.get_instrument_price
 Price data is useful, but is there any other data available? For futures, yes, we can get the data we need to implement a carry rule:
 
 ```python
-data.get_instrument_raw_carry_data("EDOLLAR").tail(6)
+data.get_instrument_raw_carry_data("SOFR").tail(6)
 
 ```
 
@@ -117,7 +117,7 @@ def calc_ewmac_forecast(price, Lfast, Lslow=None):
 Let's run it and look at the output
 
 ```python
-instrument_code='EDOLLAR'
+instrument_code='SOFR'
 price=data.daily_prices(instrument_code)
 ewmac=calc_ewmac_forecast(price, 32, 128)
 ewmac.tail(5)
@@ -250,7 +250,7 @@ System with stages: rules
 We can now get forecasts:
 
 ```python
-my_system.rules.get_raw_forecast("EDOLLAR", "ewmac").tail(5)
+my_system.rules.get_raw_forecast("SOFR", "ewmac").tail(5)
 ```
 
 ```
@@ -302,7 +302,7 @@ Again, let's check that `ewmac32` is the same as the `ewmac` we have before (it 
 
 ```python
 my_system=System([my_rules], data)
-my_system.rules.get_raw_forecast("EDOLLAR", "ewmac32").tail(5)
+my_system.rules.get_raw_forecast("SOFR", "ewmac32").tail(5)
 ```
 
 ```
@@ -336,7 +336,7 @@ So far, not exciting. Let's see how we'd use a `config` to define our trading ru
 empty_rules=Rules()
 my_config.trading_rules=dict(ewmac8=ewmac_8, ewmac32=ewmac_32)
 my_system=System([empty_rules], data, my_config)
-print(my_system.rules.get_raw_forecast("EDOLLAR", "ewmac8"))
+print(my_system.rules.get_raw_forecast("SOFR", "ewmac8"))
 ```
 
 Notice the differences from before:
@@ -363,14 +363,14 @@ from systems.forecast_scale_cap import ForecastScaleCap
 
 ## By default we pool estimates across instruments. It's worth telling the system what instruments we want to use:
 #
-my_config.instruments=["EDOLLAR", "US10", "CORN", "SP500_micro"]
+my_config.instruments=["SOFR", "US10", "CORN", "SP500_micro"]
 
 ## this parameter ensures we estimate:
 my_config.use_forecast_scale_estimates=True
 
 fcs=ForecastScaleCap()
 my_system = System([fcs, my_rules], data, my_config)
-print(my_system.forecastScaleCap.get_forecast_scalar("EDOLLAR", "ewmac32").tail(5))
+print(my_system.forecastScaleCap.get_forecast_scalar("SOFR", "ewmac32").tail(5))
 ```
 
 ```
@@ -394,10 +394,10 @@ my_config.use_forecast_scale_estimates=False
 
 my_system=System([fcs, empty_rules], data, my_config)
 
-print(my_system.forecastScaleCap.get_forecast_scalar("EDOLLAR", "ewmac32"))
+print(my_system.forecastScaleCap.get_forecast_scalar("SOFR", "ewmac32"))
 2.65 # now a single float value
 
-my_system.forecastScaleCap.get_capped_forecast("EDOLLAR", "ewmac32")
+my_system.forecastScaleCap.get_capped_forecast("SOFR", "ewmac32")
 ```
 
 *Note that the order of stages in the list passed to `System([...], ...)` isn't relevant*
@@ -421,8 +421,8 @@ from systems.forecast_combine import ForecastCombine
 
 combiner = ForecastCombine()
 my_system = System([fcs, empty_rules, combiner], data, my_config)
-my_system.combForecast.get_forecast_weights("EDOLLAR").tail(5)
-my_system.combForecast.get_forecast_diversification_multiplier("EDOLLAR").tail(5)
+my_system.combForecast.get_forecast_weights("SOFR").tail(5)
+my_system.combForecast.get_forecast_diversification_multiplier("SOFR").tail(5)
 
 ```
 
@@ -499,7 +499,7 @@ my_config.forecast_div_multiplier=1.1
 my_config.use_forecast_weight_estimates = False
 my_config.use_forecast_div_mult_estimates = False
 my_system=System([fcs, empty_rules, combiner, raw_data, position_size], data, my_config)
-my_system.combForecast.get_combined_forecast("EDOLLAR").tail(5)
+my_system.combForecast.get_combined_forecast("SOFR").tail(5)
 ```
 
 
@@ -524,7 +524,7 @@ my_config.base_currency="GBP"
 
 my_system=System([ fcs, empty_rules, combiner, position_size, raw_data], data, my_config)
 
-my_system.positionSize.get_subsystem_position("EDOLLAR").tail(5)
+my_system.positionSize.get_subsystem_position("SOFR").tail(5)
 ```
 
 
@@ -560,7 +560,7 @@ print(my_system.portfolio.get_instrument_diversification_multiplier())
 ```
 
 ```
-                CORN   EDOLLAR     SP500_micro      US10
+                CORN   SOFR     SP500_micro      US10
 2016-05-05  0.273715  0.245994  0.281982  0.198309
 2016-05-06  0.273715  0.245994  0.281982  0.198309
 2016-05-09  0.273715  0.245994  0.281982  0.198309
@@ -582,14 +582,14 @@ Alternatively we can just make up some instrument weights, and diversification m
 *Again if we really couldn't be bothered, this would default to equal weights and 1.0 respectively*
 
 ```python
-my_config.instrument_weights=dict(US10=.1, EDOLLAR=.4, CORN=.3, SP500_micro=.8)
+my_config.instrument_weights=dict(US10=.1, SOFR=.4, CORN=.3, SP500_micro=.8)
 my_config.instrument_div_multiplier=1.5
 my_config.use_instrument_weight_estimates = False
 my_config.use_instrument_div_mult_estimates = False
 
 my_system=System([ fcs, empty_rules, combiner, position_size, raw_data, portfolio], data, my_config)
 
-my_system.portfolio.get_notional_position("EDOLLAR").tail(5)
+my_system.portfolio.get_notional_position("SOFR").tail(5)
 ```
 
 ```                 
@@ -635,7 +635,7 @@ To speed things up you can also pass a dictionary to `Config()`. To reproduce th
 
 ```python
 from sysdata.config.configdata import Config
-my_config=Config(dict(trading_rules=dict(ewmac8=ewmac_8, ewmac32=ewmac_32), instrument_weights=dict(US10=.1, EDOLLAR=.4, CORN=.3, SP500_micro=.2), instrument_div_multiplier=1.5, forecast_scalars=dict(ewmac8=5.3, ewmac32=2.65), forecast_weights=dict(ewmac8=0.5, ewmac32=0.5), forecast_div_multiplier=1.1
+my_config=Config(dict(trading_rules=dict(ewmac8=ewmac_8, ewmac32=ewmac_32), instrument_weights=dict(US10=.1, SOFR=.4, CORN=.3, SP500_micro=.2), instrument_div_multiplier=1.5, forecast_scalars=dict(ewmac8=5.3, ewmac32=2.65), forecast_weights=dict(ewmac8=0.5, ewmac32=0.5), forecast_div_multiplier=1.1
 ,percentage_vol_target=25, notional_trading_capital=500000, base_currency="GBP"))
 my_config
 ```
@@ -679,7 +679,7 @@ System with stages: accounts, portfolio, positionSize, combForecast, forecastSca
 Everything will now work as before:
 
 ```python
-my_system.portfolio.get_notional_position("EDOLLAR").tail(5)
+my_system.portfolio.get_notional_position("SOFR").tail(5)
 ```
 
 


### PR DESCRIPTION
This PR updates `introduction.md`, replacing EDOLLAR with SOFR to reflect the benchmark change.  
It ensures that users following the examples don’t encounter errors due to missing EDOLLAR data.  
This is a straightforward text replacement in the document.
