### PR TITLE
Fix for an occasional crash in the P&L Report

### DIFF
--- a/sysproduction/reporting/data/pandl.py
+++ b/sysproduction/reporting/data/pandl.py
@@ -286,10 +286,6 @@ class pandlCalculateAndStore(object):
             )
             strategy_pandl_store[store_key] = pandl_series
 
-        # set index type to datetime, and sort
-        pandl_series.index = pd.to_datetime(pandl_series.index)
-        pandl_series.sort_index(inplace=True)
-
         return pandl_series
 
     def _get_perc_pandl_series_for_strategy_instrument_vs_total_capital(

--- a/sysproduction/reporting/data/pandl.py
+++ b/sysproduction/reporting/data/pandl.py
@@ -174,7 +174,7 @@ class pandlCalculateAndStore(object):
     def get_period_perc_pandl_for_instrument_all_strategies_in_date_range(
         self, instrument_code: str
     ) -> float:
-        print("Getting p&l for %s" % instrument_code)
+        self.data.log.info("Getting p&l for %s" % instrument_code)
 
         try:
             pandl_across_contracts = self.pandl_for_instrument_across_contracts(
@@ -223,7 +223,7 @@ class pandlCalculateAndStore(object):
         return pandl_df
 
     def get_period_perc_pandl_for_strategy_in_date_range(self, strategy_name: str):
-        print("Getting p&l for %s" % strategy_name)
+        self.data.log.info("Getting p&l for %s" % strategy_name)
         try:
             pandl_df = self.get_df_of_perc_pandl_series_for_strategy_all_instruments(
                 strategy_name
@@ -285,6 +285,10 @@ class pandlCalculateAndStore(object):
                 )
             )
             strategy_pandl_store[store_key] = pandl_series
+
+        # set index type to datetime, and sort
+        pandl_series.index = pd.to_datetime(pandl_series.index)
+        pandl_series.sort_index(inplace=True)
 
         return pandl_series
 
@@ -388,7 +392,7 @@ def get_perc_pandl_series_for_contract(data, instrument_code, contract_id):
 def get_perc_pandl_series_for_strategy_instrument_vs_total_capital(
     data, instrument_strategy: instrumentStrategy
 ):
-    print("Data for %s" % (instrument_strategy))
+    data.log.info("Data for %s" % instrument_strategy)
     instrument_code = instrument_strategy.instrument_code
     strategy_name = instrument_strategy.strategy_name
 

--- a/systems/accounts/pandl_calculators/pandl_using_fills.py
+++ b/systems/accounts/pandl_calculators/pandl_using_fills.py
@@ -101,6 +101,7 @@ def merge_fill_prices_with_prices(
         [prices, unique_trades_as_pd_df.price], axis=1, join="outer"
     )
     prices_to_use.columns = ["price", "fill_price"]
+    prices_to_use.index = pd.to_datetime(prices_to_use.index)
 
     # Where no fill price available, use price
     prices_to_use = prices_to_use.ffill(axis=1)


### PR DESCRIPTION
This can happen when you have moved to a new strategy, and there are instruments for which there have been no trades yet. 

P&L data for an instrument in a strategy is generated by first building a series of prices at `merge_fill_prices_with_prices()` from `systems.accounts.pandl_calculators.pandl_using_fills.py`. A series of P&L values is built from the prices, and then the P&L series are later concatenated into a dataframe at `get_df_of_perc_pandl_series_for_strategy_all_instruments()` in `sysproduction.reporting.data.pandl.py`

When there are no trades yet for the new strategy, the empty series of prices has an index of dtype `object`. That causes the P&L dataframe to be corrupted, only containing data for the final instrument. That causes the crash.

The fix is to set the index to be of `datetime` type, even for an empty series

Also changes the `pandl` module `print()` statements to `log.info()`