### PR TITLE
handle missing price data during strategy order generation

### DIFF
--- a/sysproduction/data/risk.py
+++ b/sysproduction/data/risk.py
@@ -93,8 +93,9 @@ def get_annualised_stdev_perc_of_instruments(data, instrument_list) -> stdevEsti
 def get_perc_returns_across_instruments(data, instrument_list: list) -> pd.DataFrame:
     perc_returns = dict(
         [
-            (instrument_code, get_daily_perc_returns_for_risk(data, instrument_code))
-            for instrument_code in instrument_list
+            (instr, returns)
+            for instr in instrument_list
+            if len(returns := get_daily_perc_returns_for_risk(data, instr)) > 0
         ]
     )
     price_df = pd.DataFrame(perc_returns)


### PR DESCRIPTION
ensure frame of percentage returns only includes instruments where there is data. Fix for #1513 