### PR TITLE
fix incorrect timestamps in spread price series

### DIFF
--- a/sysobjects/spreads.py
+++ b/sysobjects/spreads.py
@@ -6,7 +6,9 @@ from syscore.exceptions import missingData
 
 
 class spreadsForInstrument(pd.Series):
-    def add_spread(self, spread: float, current_time=datetime.datetime.now()):
+    def add_spread(self, spread: float, current_time=None):
+        if current_time is None:
+            current_time = datetime.datetime.now()
         new_row = pd.Series(spread, index=[current_time])
 
         return spreadsForInstrument(pd.concat([self, new_row], axis=0))


### PR DESCRIPTION
Refactor add_spread to compute current_time internally. Moved the `current_time` computation inside the method to ensure the timestamp is always generated at the time of method execution