### PR TITLE
Various minor bug fixes / improvements

### DIFF
--- a/.github/workflows/os-test.yml
+++ b/.github/workflows/os-test.yml
@@ -10,8 +10,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14, windows-2022 ]
-        python-version: [ 3.11.9 ]
+        os: [ ubuntu-latest, macos-15-intel, macos-15, windows-2022 ]
+        python-version: [ '3.10', '3.11', '3.12' ]
 
     steps:
 

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -1517,7 +1517,21 @@ system.cache.get_items_with_data() ## Cache is now populated. Any existing data 
 system.get_itemnames_for_stage("accounts") ## now doesn't include ('accounts', 'portfolio', 'percentageTdelayfillTroundpositionsT')
 
 system.accounts.portfolio().sharpe() ## Not coming from the cache, but this will run much faster and reuse many previous calculations
+```
 
+The pickle files are large. Turn on backtest compression to save space
+
+```python
+from systems.provided.futures_chapter15.basesystem import futures_system
+
+system = futures_system()
+system.config.backtest_compress = True 
+system.cache.pickle("private.this_system_name.system.pckz") 
+
+# Now in a new session
+system = futures_system()
+system.cache.get_items_with_data()
+system.cache.unpickle("private.this_system_name.system.pckz")
 ```
 
 See [here](#file-names) for how to specify filenames in pysystemtrade.

--- a/sysbrokers/IB/ib_broker_commissions.py
+++ b/sysbrokers/IB/ib_broker_commissions.py
@@ -48,8 +48,13 @@ class ibFuturesContractCommissionData(brokerFuturesContractCommissionData):
         instrument_code = futures_contract.instrument_code
         contract_date = futures_contract.contract_date.list_of_date_str[0]
 
+        broker_account = self.data.config.get_element("broker_account")
         broker_order = brokerOrder(
-            test_commission_strategy, instrument_code, contract_date, size_of_test_trade
+            test_commission_strategy,
+            instrument_code,
+            contract_date,
+            size_of_test_trade,
+            broker_account=broker_account,
         )
 
         order = self.execution_stack.what_if_order(broker_order)
@@ -75,4 +80,4 @@ def get_commission_and_currency_from_ib_order(
 
 
 test_commission_strategy = "testCommmission"  ## whatever not put on stack
-size_of_test_trade = 10  ## arbitrary
+size_of_test_trade = 1  ## arbitrary

--- a/syscore/dateutils.py
+++ b/syscore/dateutils.py
@@ -495,6 +495,7 @@ def contract_month_from_number(month_number: int) -> str:
 Convert date into a decimal, and back again
 """
 LONG_DATE_FORMAT = "%Y%m%d%H%M%S.%f"
+ISO_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 CONVERSION_FACTOR = 10000
 
 
@@ -542,7 +543,7 @@ MISSING_STRING_PATTERN = "     ???      "
 
 
 def date_as_short_pattern_or_question_if_missing(
-    last_run_or_heartbeat: datetime.datetime,
+    last_run_or_heartbeat: datetime.datetime, date_format=SHORT_DATE_PATTERN
 ) -> str:
     """
     Check time matches at one second resolution (good enough)
@@ -553,7 +554,7 @@ def date_as_short_pattern_or_question_if_missing(
     '     ???      '
     """
     if isinstance(last_run_or_heartbeat, datetime.datetime):
-        last_run_or_heartbeat = last_run_or_heartbeat.strftime(SHORT_DATE_PATTERN)
+        last_run_or_heartbeat = last_run_or_heartbeat.strftime(date_format)
     else:
         last_run_or_heartbeat = MISSING_STRING_PATTERN
 

--- a/syscore/fileutils.py
+++ b/syscore/fileutils.py
@@ -172,7 +172,7 @@ def get_resolved_pathname(pathname: str) -> str:
         # special case when already a Path
         pathname = str(pathname.absolute())
 
-    if "@" in pathname:
+    if "@" in pathname or "::" in pathname:
         # This is an ssh address for rsync - don't change
         return pathname
 

--- a/syscore/fileutils.py
+++ b/syscore/fileutils.py
@@ -366,8 +366,9 @@ def files_with_extension_in_resolved_pathname(
     Find all the files with a particular extension in a directory
     """
 
-    file_list = os.listdir(resolved_pathname)
-    file_list = [filename for filename in file_list if filename.endswith(extension)]
+    file_list = [
+        os.path.basename(f) for f in glob.glob(f"{resolved_pathname}/*{extension}")
+    ]
     file_list_no_extension = [filename.split(".")[0] for filename in file_list]
 
     return file_list_no_extension

--- a/syscore/pandas/pdutils.py
+++ b/syscore/pandas/pdutils.py
@@ -365,6 +365,25 @@ def from_series_to_df_with_column_names(
     return new_df
 
 
+def print_full(x):
+    """
+    Prints out a pd dataframe with no truncation, then sets display options back to
+    their defaults
+    :param x:
+    :type x:
+    """
+    pd.set_option("display.max_rows", None)
+    pd.set_option("display.max_columns", None)
+    pd.set_option("display.width", 2000)
+    pd.set_option("display.max_colwidth", None)
+    print(x)
+    pd.reset_option("display.max_rows")
+    pd.reset_option("display.max_columns")
+    pd.reset_option("display.width")
+    pd.reset_option("display.float_format")
+    pd.reset_option("display.max_colwidth")
+
+
 if __name__ == "__main__":
     import doctest
 

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -22,12 +22,16 @@ strategy_capital_allocation:
 #
 ## Where do we save backtests
 backtest_store_directory: 'private.backtests'
+backtest_max_age: 30
 backtest_compress: False
 #
 # And backups
 csv_backup_directory: 'data.backups_csv'
 mongo_dump_directory: 'data.mongo_dump'
+# if mongo_dump_all is True, we dump all databases, otherwise just PST dbs
+mongo_dump_all: True
 echo_directory: 'data.echos'
+offsystem_backup_options: '-av'
 #
 # Interactive brokers
 ib_ipaddress: 127.0.0.1

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -22,6 +22,7 @@ strategy_capital_allocation:
 #
 ## Where do we save backtests
 backtest_store_directory: 'private.backtests'
+backtest_compress: False
 #
 # And backups
 csv_backup_directory: 'data.backups_csv'

--- a/sysdata/mongodb/tests/test_mongodb.py
+++ b/sysdata/mongodb/tests/test_mongodb.py
@@ -39,3 +39,8 @@ class TestMongoDB:
         clean_sharded = clean_mongo_host(sharded)
         print(clean_sharded)
         assert "D1fficultP%40ssw0rd" not in clean_sharded
+
+        server = "mongodb+srv://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin"
+        clean_server = clean_mongo_host(server)
+        print(clean_server)
+        assert "D1fficultP%40ssw0rd" not in clean_server

--- a/sysexecution/stack_handler/additional_sampling.py
+++ b/sysexecution/stack_handler/additional_sampling.py
@@ -1,4 +1,4 @@
-from syscore.exceptions import missingData
+from syscore.exceptions import missingData, missingContract
 from sysexecution.stack_handler.stackHandlerCore import stackHandlerCore
 from sysobjects.contracts import futuresContract
 
@@ -53,7 +53,7 @@ class stackHandlerAdditionalSampling(stackHandlerCore):
     def refresh_sampling_without_checks(self, contract: futuresContract):
         try:
             average_spread = self.get_average_spread(contract)
-        except missingData:
+        except (missingData, missingContract):
             pass
         else:
             self.add_spread_data_to_db(contract, average_spread)

--- a/syslogging/server.py
+++ b/syslogging/server.py
@@ -120,5 +120,9 @@ def logging_server():
     return 0
 
 
-if __name__ == "__main__":
+def run():
     sys.exit(logging_server())
+
+
+if __name__ == "__main__":
+    run()

--- a/sysobjects/production/process_control.py
+++ b/sysobjects/production/process_control.py
@@ -19,6 +19,7 @@ from syscore.fileutils import write_list_of_lists_as_html_table_in_file
 from syscore.dateutils import (
     SECONDS_PER_DAY,
     date_as_short_pattern_or_question_if_missing,
+    ISO_DATE_FORMAT,
 )
 
 from syscore.constants import (
@@ -335,10 +336,14 @@ class controlProcess(object):
     def as_printable_dict(self) -> dict:
         run_string = self.running_mode_str
         return dict(
-            start=date_as_short_pattern_or_question_if_missing(self.last_start_time),
-            end=date_as_short_pattern_or_question_if_missing(self.last_end_time),
+            start=date_as_short_pattern_or_question_if_missing(
+                self.last_start_time, date_format=ISO_DATE_FORMAT
+            ),
+            end=date_as_short_pattern_or_question_if_missing(
+                self.last_end_time, date_format=ISO_DATE_FORMAT
+            ),
             status=self.status,
-            PID=self.process_id,
+            PID=int(self.process_id),
             running=run_string,
         )
 

--- a/sysproduction/backup_db_to_csv.py
+++ b/sysproduction/backup_db_to_csv.py
@@ -4,6 +4,7 @@ import pandas as pd
 from syscore.exceptions import missingData
 from syscore.pandas.pdutils import check_df_equals, check_ts_equals
 from syscore.dateutils import CALENDAR_DAYS_IN_YEAR
+from sysdata.config.production_config import get_production_config
 from sysdata.data_blob import dataBlob
 
 from sysdata.csv.csv_futures_contracts import csvFuturesContractData
@@ -57,7 +58,7 @@ class backupDbToCsv:
         backup_data = get_data_and_create_csv_directories(self.data.log_name)
         log = self.data.log
 
-        log.debug("Dumping from arctic, mongo to .csv files")
+        log.debug("Dumping from db, mongo to .csv files")
         backup_adj_to_csv(backup_data)
         backup_futures_contract_prices_to_csv(backup_data)
         backup_spreads_to_csv(backup_data)
@@ -71,7 +72,7 @@ class backupDbToCsv:
         backup_spread_cost_data(backup_data)
         backup_optimal_positions(backup_data)
         backup_roll_state_data(backup_data)
-        log.debug("Copying to backup directory")
+        log.debug("Copying to offsystem backup directory")
         backup_csv_dump(self.data)
 
 
@@ -484,7 +485,8 @@ def backup_csv_dump(data):
     source_path = get_csv_dump_dir()
     destination_path = get_csv_backup_directory()
     data.log.debug("Copy from %s to %s" % (source_path, destination_path))
-    os.system("rsync -av %s %s" % (source_path, destination_path))
+    options = get_production_config().get_element("offsystem_backup_options")
+    os.system(f"rsync {options} {source_path} {destination_path}")
 
 
 if __name__ == "__main__":

--- a/sysproduction/backup_parquet_data_to_remote.py
+++ b/sysproduction/backup_parquet_data_to_remote.py
@@ -7,7 +7,7 @@ from sysdata.data_blob import dataBlob
 
 
 def backup_parquet_data_to_remote():
-    data = dataBlob(log_name="backup_mongo_data_as_dump")
+    data = dataBlob(log_name="backup_parquet_data_to_remote")
     backup_object = backupParquet(data)
     backup_object.backup_parquet()
 
@@ -25,7 +25,7 @@ class backupParquet(object):
     def backup_parquet(self):
         data = self.data
         log = data.log
-        log.debug("Copying data to backup destination")
+        log.debug("Copying data to offsystem backup destination")
         backup_parquet_data_to_remote_with_data(data)
 
 
@@ -33,7 +33,8 @@ def backup_parquet_data_to_remote_with_data(data):
     source_path = get_parquet_directory(data)
     destination_path = get_parquet_backup_directory()
     data.log.debug("Copy from %s to %s" % (source_path, destination_path))
-    os.system("rsync -av %s %s" % (source_path, destination_path))
+    options = get_production_config().get_element("offsystem_backup_options")
+    os.system(f"rsync {options} {source_path} {destination_path}")
 
 
 if __name__ == "__main__":

--- a/sysproduction/backup_state_files.py
+++ b/sysproduction/backup_state_files.py
@@ -1,5 +1,6 @@
 import os
 
+from sysdata.config.production_config import get_production_config
 from sysproduction.data.directories import (
     get_statefile_directory,
     get_statefile_backup_directory,
@@ -21,7 +22,7 @@ class backupStateFiles(object):
 
     def backup_files(self):
         data = self.data
-        self.data.log.debug("Backing up state files")
+        self.data.log.debug("Copying to offsystem backup directory")
         backup_state_files_with_data_object(data)
 
 
@@ -29,7 +30,8 @@ def backup_state_files_with_data_object(data):
     source_path = get_statefile_directory()
     destination_path = get_statefile_backup_directory()
     data.log.debug("Copy from %s to %s" % (source_path, destination_path))
-    os.system("rsync -av %s %s" % (source_path, destination_path))
+    options = get_production_config().get_element("offsystem_backup_options")
+    os.system(f"rsync {options} {source_path} {destination_path}")
 
 
 if __name__ == "__main__":

--- a/sysproduction/clean_truncate_backtest_states.py
+++ b/sysproduction/clean_truncate_backtest_states.py
@@ -25,6 +25,9 @@ class cleanTruncateBacktestStates:
             directory_to_use, days_old=30, extension=".pck"
         )
         delete_old_files_with_extension_in_pathname(
+            directory_to_use, days_old=30, extension=".pckz"
+        )
+        delete_old_files_with_extension_in_pathname(
             directory_to_use, days_old=30, extension=".yaml"
         )
 

--- a/sysproduction/clean_truncate_backtest_states.py
+++ b/sysproduction/clean_truncate_backtest_states.py
@@ -1,5 +1,6 @@
 from syscore.fileutils import delete_old_files_with_extension_in_pathname
 from sysproduction.data.backtest import get_directory_store_backtests
+from sysdata.config.production_config import get_production_config
 from sysdata.data_blob import dataBlob
 
 
@@ -17,18 +18,20 @@ class cleanTruncateBacktestStates:
 
     def clean_backtest_states(self):
         directory_to_use = get_directory_store_backtests()
+        max_age = get_production_config().get_element("backtest_max_age")
+
         self.data.log.debug(
             "Deleting old .pck and .yaml backtest state files in directory %s"
             % directory_to_use
         )
         delete_old_files_with_extension_in_pathname(
-            directory_to_use, days_old=30, extension=".pck"
+            directory_to_use, days_old=max_age, extension=".pck"
         )
         delete_old_files_with_extension_in_pathname(
-            directory_to_use, days_old=30, extension=".pckz"
+            directory_to_use, days_old=max_age, extension=".pckz"
         )
         delete_old_files_with_extension_in_pathname(
-            directory_to_use, days_old=30, extension=".yaml"
+            directory_to_use, days_old=max_age, extension=".yaml"
         )
 
 

--- a/sysproduction/data/backtest.py
+++ b/sysproduction/data/backtest.py
@@ -22,10 +22,12 @@ from sysproduction.data.strategies import (
 
 
 PICKLE_EXT = ".pck"
+COMPRESSED_PICKLE_EXT = ".pckz"
 CONFIG_EXT = ".yaml"
 PICKLE_FILE_SUFFIX = "_backtest"
 CONFIG_FILE_SUFFIX = "_config"
 PICKLE_SUFFIX = PICKLE_FILE_SUFFIX + PICKLE_EXT
+COMPRESSED_PICKLE_SUFFIX = PICKLE_FILE_SUFFIX + COMPRESSED_PICKLE_EXT
 CONFIG_SUFFIX = CONFIG_FILE_SUFFIX + CONFIG_EXT
 
 
@@ -177,7 +179,10 @@ def load_backtest_state(system, strategy_name, date_time_signature):
 
     :return: system with cache filled from pickled backtest state file
     """
-    filename = get_backtest_pickle_filename(strategy_name, date_time_signature)
+    compress = system.config.get_element("backtest_compress")
+    filename = get_backtest_pickle_filename(
+        strategy_name, date_time_signature, compress
+    )
     system.cache.unpickle(filename)
 
     return system
@@ -199,7 +204,10 @@ def store_backtest_state(data, system, strategy_name="default_strategy"):
 
     datetime_marker = create_datetime_marker_string()
 
-    pickle_filename = get_backtest_pickle_filename(strategy_name, datetime_marker)
+    compress = system.config.get_element("backtest_compress")
+    pickle_filename = get_backtest_pickle_filename(
+        strategy_name, datetime_marker, compress
+    )
     pickle_state(data, system, pickle_filename)
 
     config_save_filename = get_backtest_config_filename(strategy_name, datetime_marker)
@@ -224,16 +232,20 @@ def rchop(s, suffix):
 
 def get_list_of_pickle_files_for_strategy(strategy_name):
     full_directory = get_backtest_directory_for_strategy(strategy_name)
-    list_of_files = files_with_extension_in_pathname(full_directory, PICKLE_EXT)
+    list_of_files = files_with_extension_in_pathname(full_directory, ".pck*")
 
     return list_of_files
 
 
-def get_backtest_pickle_filename(strategy_name, datetime_marker):
+def get_backtest_pickle_filename(
+    strategy_name,
+    datetime_marker,
+    compress=False,
+):
     # eg
     # '/home/rob/data/backtests/medium_speed_TF_carry/20200616_122543_backtest.pck'
     prefix = get_backtest_filename_prefix(strategy_name, datetime_marker)
-    suffix = PICKLE_SUFFIX
+    suffix = COMPRESSED_PICKLE_SUFFIX if compress else PICKLE_SUFFIX
 
     return prefix + suffix
 

--- a/sysproduction/data/risk.py
+++ b/sysproduction/data/risk.py
@@ -150,11 +150,13 @@ def get_perc_of_strategy_capital_for_instrument_per_contract(
     data, strategy_name, instrument_code
 ):
     capital_base_fx = capital_for_strategy(data, strategy_name)
-    exposure_per_contract = get_exposure_per_contract_base_currency(
-        data, instrument_code
-    )
-
-    return exposure_per_contract / capital_base_fx
+    if capital_base_fx == 0.0:
+        return 0.0
+    else:
+        exposure_per_contract = get_exposure_per_contract_base_currency(
+            data, instrument_code
+        )
+        return exposure_per_contract / capital_base_fx
 
 
 def get_current_ann_stdev_of_prices(data, instrument_code):

--- a/sysproduction/reporting/data/pricechanges.py
+++ b/sysproduction/reporting/data/pricechanges.py
@@ -39,7 +39,7 @@ class marketMovers(object):
         return all_moves_as_df
 
     def get_market_move_for_instrument_and_dates(self, instrument_code: str) -> dict:
-        print(instrument_code)
+        self.data.log.info(instrument_code)
         start_date = self.start_date
         end_date = self.end_date
 
@@ -64,7 +64,7 @@ class marketMovers(object):
     def get_market_moves_for_period(self, period: str) -> pd.DataFrame:
         self._end_date = datetime.datetime.now()
 
-        print("Getting data for %s" % period)
+        self.data.log.info("Getting data for %s" % period)
         # ['name', 'change', 'vol_adjusted']
         list_of_instruments = get_list_of_instruments(self.data, source="multiple")
         all_moves: List[Dict[str, Any]] = []
@@ -86,7 +86,7 @@ class marketMovers(object):
     def get_market_move_for_instrument_and_period(
         self, instrument_code: str, period: str
     ) -> dict:
-        print(instrument_code)
+        self.data.log.info(instrument_code)
         start_date = self.start_date_for_period(period)
         end_date = self.end_date
 

--- a/systems/accounts/curves/account_curve.py
+++ b/systems/accounts/curves/account_curve.py
@@ -318,6 +318,8 @@ class accountCurve(pd.Series):
     def hitrate(self):
         no_gains = float(self.gains().shape[0])
         no_losses = float(self.losses().shape[0])
+        if (no_losses + no_gains) == 0.0:
+            return 0.0
         return no_gains / (no_losses + no_gains)
 
     def rolling_ann_std(self, window=40):

--- a/systems/portfolio.py
+++ b/systems/portfolio.py
@@ -1278,7 +1278,8 @@ class Portfolios(SystemStage):
             for (
                 instrument_code_to_remove
             ) in allocate_zero_instrument_weights_to_these_instruments:
-                instrument_list.remove(instrument_code_to_remove)
+                if instrument_code_to_remove in instrument_list:
+                    instrument_list.remove(instrument_code_to_remove)
 
         return instrument_list
 

--- a/systems/provided/dynamic_small_system_optimise/optimised_positions_stage.py
+++ b/systems/provided/dynamic_small_system_optimise/optimised_positions_stage.py
@@ -388,10 +388,12 @@ def calculate_cost_per_notional_weight_as_proportion_of_capital(
     capital: float,
     cost_multiplier: float = 1.0,
 ) -> float:
-    dollar_cost = (
-        cost_multiplier
-        * cost_per_contract
-        / notional_value_per_contract_as_proportion_of_capital
-    )
-
-    return dollar_cost / capital
+    if capital == 0.0:
+        return 0.0
+    else:
+        dollar_cost = (
+            cost_multiplier
+            * cost_per_contract
+            / notional_value_per_contract_as_proportion_of_capital
+        )
+        return dollar_cost / capital

--- a/systems/system_cache.py
+++ b/systems/system_cache.py
@@ -14,6 +14,7 @@ There are 3 kinds of things in a cache with different levels of persistence:
 
 from syscore.fileutils import resolve_path_and_filename_for_package
 import pickle
+import bz2
 from functools import wraps
 
 """
@@ -212,8 +213,12 @@ class systemCache(dict):
         cache_to_pickle = self.partial_cache(pickable_cache_refs)
         cache_to_pickle_as_dict = cache_to_pickle.as_dict()
 
-        with open(filename, "wb+") as fhandle:
-            pickle.dump(cache_to_pickle_as_dict, fhandle)
+        if self._parent.config.get_element("backtest_compress"):
+            with bz2.open(filename, "wb") as fhandle:
+                pickle.dump(cache_to_pickle_as_dict, fhandle)
+        else:
+            with open(filename, "wb+") as fhandle:
+                pickle.dump(cache_to_pickle_as_dict, fhandle)
 
     def as_dict(self):
         self_as_dict = {}
@@ -246,8 +251,12 @@ class systemCache(dict):
 
         filename = resolve_path_and_filename_for_package(relativefilename)
 
-        with open(filename, "rb") as fhandle:
-            cache_from_pickled = pickle.load(fhandle)
+        if self._parent.config.get_element("backtest_compress"):
+            with bz2.open(filename, "rb") as fhandle:
+                cache_from_pickled = pickle.load(fhandle)
+        else:
+            with open(filename, "rb") as fhandle:
+                cache_from_pickled = pickle.load(fhandle)
 
         if clearcache:
             self.clear()


### PR DESCRIPTION
- fix several 'divide by zero' errors
- fix param name bug in mongoDb()
- fix for a zero weight bug in portfolio.py
- option to only dump PST related database from mongodb
- improve logging during offsystem backup
- support '::' in offsystem backup target uri
- configurable rsync options in offsystem backup config
- option to compress backtest pickle files
- configurable max age of backtest files
- support Atlas MongoDB URIs
- remove soon to be deprecated macos image from github action
- reduce commission report errors
- use logging instead of print() in report code
- ability to print out full wide data frame
- improved output in process control monitor