### PR TITLE
Fix issue #1569

### DIFF
--- a/sysexecution/order_stacks/instrument_order_stack.py
+++ b/sysexecution/order_stacks/instrument_order_stack.py
@@ -36,6 +36,12 @@ class instrumentOrderStackData(orderStackData):
 
         return True
 
+    def does_stack_have_orders_for_instrument_code(self, instrument_code: str) -> bool:
+        orders_with_instrument_code = self.list_of_orders_with_instrument_code(
+            instrument_code
+        )
+        return len(orders_with_instrument_code) > 0
+
     def list_of_strategies_with_orders_on_stack_for_instrument(
         self, instrument_code: str
     ) -> bool:

--- a/sysexecution/stack_handler/roll_orders.py
+++ b/sysexecution/stack_handler/roll_orders.py
@@ -155,7 +155,7 @@ class stackHandlerForRolls(stackHandlerCore):
         ## Check other strategies for orders
         ##  (note this will return True if it's a roll order so we'd get an email if we hadn't already exited)
         any_order_for_instrument_already_on_stack = (
-            self.check_and_warn_if_order_for_instrument_already_on_contract_stack(
+            self.check_and_warn_if_order_for_instrument_already_on_stack(
                 instrument_code
             )
         )
@@ -172,11 +172,11 @@ class stackHandlerForRolls(stackHandlerCore):
 
         return order_already_on_stack
 
-    def check_and_warn_if_order_for_instrument_already_on_contract_stack(
+    def check_and_warn_if_order_for_instrument_already_on_stack(
         self, instrument_code: str
     ) -> bool:
         orders_already_on_stack = (
-            self.contract_stack.does_stack_have_orders_for_instrument_code(
+            self.instrument_stack.does_stack_have_orders_for_instrument_code(
                 instrument_code
             )
         )
@@ -185,7 +185,7 @@ class stackHandlerForRolls(stackHandlerCore):
             ## Need to warn user so they can take action if required
 
             self.log.critical(
-                "Cannot force roll %s as already other orders on contract stack"
+                "Cannot force roll %s as already other orders on stack"
                 % (instrument_code),
                 instrument_code=instrument_code,
             )


### PR DESCRIPTION
Fixes #1569

After playing around with this a bit, I've decided that the only necessary change is to check the instrument stack (not the contract stack) for existing orders  before creating roll orders.

Roll orders will not be created when there is already an order on the stack for that instrument.  As before, strategy contract orders are not generated when roll status is Force, Force Outright, Close, or Roll Adjusted.

There will be a CRITICAL log message that the roll could not be executed.  CRITICAL log messages are meant to generate an email if the logging and the email settings are properly configured.

The user then has the choice to either delete the strategy order and execute the roll, or to change the roll status and allow the strategy order to be executed.

I prefer this because it is simpler, and it lets the user choose, rather than assuming the roll should take precedence, although it does require manual intervention.  I believe this is how it was originally intended to work.
