### PR TITLE
optional strategy order warnings where the instrument is in force roll status

### DIFF
--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -322,9 +322,9 @@ small_system:
   tracking_error_buffer: 0.0125
   shrink_instrument_returns_correlation: 0.5
 #
-# Instruments with a region (ASIA, EMEA, US) listed here will be issued warnings
-# by the strategy order generator if the instrument is in Force or Force
-# Outright status. Leave empty for no warnings
+# Instruments with a region (ASIA, EMEA, US) listed here will cause warnings to
+# be issued by the strategy order generator if the instrument has 'active' roll
+# status (Force, Force Outright, Close, Roll Adjusted). Leave empty for no action
 regions_with_warn_on_force_orders: []
 #
 # duplicated/excluded instruments are ignored in backtests

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -322,6 +322,11 @@ small_system:
   tracking_error_buffer: 0.0125
   shrink_instrument_returns_correlation: 0.5
 #
+# Instruments with a region (ASIA, EMEA, US) listed here will be issued warnings
+# by the strategy order generator if the instrument is in Force or Force
+# Outright status. Leave empty for no warnings
+regions_with_warn_on_force_orders: []
+#
 # duplicated/excluded instruments are ignored in backtests
 # we still collect price data for them in production, do rolls etc
 # this is to avoid double counting of basically the same instrument

--- a/sysexecution/strategies/strategy_order_handling.py
+++ b/sysexecution/strategies/strategy_order_handling.py
@@ -12,6 +12,7 @@ from sysexecution.orders.instrument_orders import instrumentOrder
 from sysexecution.order_stacks.instrument_order_stack import zeroOrderException
 from syslogging.logger import *
 from sysproduction.data.positions import diagPositions
+from sysproduction.data.instruments import diagInstruments
 from sysproduction.data.orders import dataOrders
 from sysproduction.data.controls import diagOverrides, dataLocks, dataPositionLimits
 
@@ -28,9 +29,18 @@ class orderGeneratorForStrategy(object):
     def __init__(self, data: dataBlob, strategy_name: str):
         self._strategy_name = strategy_name
         self._data = data
-        data_orders = dataOrders(data)
         self._log = data.log
-        self._data_orders = data_orders
+
+        self._data_orders = dataOrders(data)
+        self._diag_positions = diagPositions(data)
+        self._diag_overrides = diagOverrides(data)
+        self._data_position_limits = dataPositionLimits(data)
+        self._data_lock = dataLocks(data)
+        self._diag_instruments = diagInstruments(data)
+
+        self.warn_regions = data.config.get_element_or_default(
+            "regions_with_warn_on_force_orders", []
+        )
 
     @property
     def data(self) -> dataBlob:
@@ -47,6 +57,26 @@ class orderGeneratorForStrategy(object):
     @property
     def data_orders(self):
         return self._data_orders
+
+    @property
+    def diag_positions(self):
+        return self._diag_positions
+
+    @property
+    def diag_overrides(self):
+        return self._diag_overrides
+
+    @property
+    def data_position_limits(self):
+        return self._data_position_limits
+
+    @property
+    def data_lock(self):
+        return self._data_lock
+
+    @property
+    def diag_instruments(self):
+        return self._diag_instruments
 
     @property
     def order_stack(self):
@@ -71,12 +101,10 @@ class orderGeneratorForStrategy(object):
 
         :return: dict, keys are instrument codes, values are positions
         """
-        data = self.data
         strategy_name = self.strategy_name
 
-        diag_positions = diagPositions(data)
-        actual_positions = diag_positions.get_dict_of_actual_positions_for_strategy(
-            strategy_name
+        actual_positions = (
+            self.diag_positions.get_dict_of_actual_positions_for_strategy(strategy_name)
         )
 
         return actual_positions
@@ -113,16 +141,15 @@ class orderGeneratorForStrategy(object):
         :return: int, updated position
         """
 
-        diag_overrides = diagOverrides(self.data)
-        diag_positions = diagPositions(self.data)
-
         instrument_strategy = proposed_order.instrument_strategy
 
-        original_position = diag_positions.get_current_position_for_instrument_strategy(
-            instrument_strategy
+        original_position = (
+            self.diag_positions.get_current_position_for_instrument_strategy(
+                instrument_strategy
+            )
         )
 
-        override = diag_overrides.get_cumulative_override_for_instrument_strategy(
+        override = self.diag_overrides.get_cumulative_override_for_instrument_strategy(
             instrument_strategy
         )
 
@@ -148,8 +175,7 @@ class orderGeneratorForStrategy(object):
     ) -> instrumentOrder:
         log_attrs = {**order.log_attributes(), "method": "temp"}
 
-        data_position_limits = dataPositionLimits(self.data)
-        new_order = data_position_limits.apply_position_limit_to_order(order)
+        new_order = self.data_position_limits.apply_position_limit_to_order(order)
 
         if new_order.trade != order.trade:
             if new_order.is_zero_trade():
@@ -168,14 +194,15 @@ class orderGeneratorForStrategy(object):
         return new_order
 
     def submit_order_list(self, order_list: listOfOrders):
-        data_lock = dataLocks(self.data)
         for order in order_list:
             # try:
             # we allow existing orders to be modified
             log_attrs = {**order.log_attributes(), "method": "temp"}
             self.log.debug("Required order %s" % str(order), **log_attrs)
 
-            instrument_locked = data_lock.is_instrument_locked(order.instrument_code)
+            instrument_locked = self.data_lock.is_instrument_locked(
+                order.instrument_code
+            )
             if instrument_locked:
                 self.log.debug("Instrument locked, not submitting", **log_attrs)
                 continue
@@ -203,3 +230,22 @@ class orderGeneratorForStrategy(object):
                 % (str(order), order_id),
                 **log_attrs,
             )
+            # if configured for the instrument region, issue a warning if the instrument
+            # has Force/Force Outright state
+            if self.needs_force_warning(order):
+                roll_state = self.diag_positions.get_name_of_roll_state(
+                    order.instrument_code
+                )
+                self.log.critical(
+                    f"Order created for instrument with roll status {roll_state}",
+                    **log_attrs,
+                )
+
+    def needs_force_warning(self, order: instrumentOrder) -> bool:
+        instr_region = self.diag_instruments.get_region(order.instrument_code)
+        return (
+            instr_region in self.warn_regions
+            and self.diag_positions.is_double_sided_trade_roll_state(
+                order.instrument_code
+            )
+        )

--- a/sysexecution/strategies/strategy_order_handling.py
+++ b/sysexecution/strategies/strategy_order_handling.py
@@ -15,6 +15,7 @@ from sysproduction.data.positions import diagPositions
 from sysproduction.data.instruments import diagInstruments
 from sysproduction.data.orders import dataOrders
 from sysproduction.data.controls import diagOverrides, dataLocks, dataPositionLimits
+from sysobjects.production.roll_state import is_type_of_active_rolling_roll_state
 
 name_of_main_generator_method = "get_and_place_orders"
 
@@ -231,21 +232,17 @@ class orderGeneratorForStrategy(object):
                 **log_attrs,
             )
             # if configured for the instrument region, issue a warning if the instrument
-            # has Force/Force Outright state
+            # has an active roll state
             if self.needs_force_warning(order):
-                roll_state = self.diag_positions.get_name_of_roll_state(
-                    order.instrument_code
-                )
                 self.log.critical(
-                    f"Order created for instrument with roll status {roll_state}",
+                    f"Order created for instrument with active roll state",
                     **log_attrs,
                 )
 
     def needs_force_warning(self, order: instrumentOrder) -> bool:
         instr_region = self.diag_instruments.get_region(order.instrument_code)
+        roll_state = self.diag_positions.get_name_of_roll_state(order.instrument_code)
         return (
             instr_region in self.warn_regions
-            and self.diag_positions.is_double_sided_trade_roll_state(
-                order.instrument_code
-            )
+            and is_type_of_active_rolling_roll_state(roll_state)
         )


### PR DESCRIPTION
This change extends @tgibson11's fix for #1569 as discussed [here](https://github.com/robcarver17/pysystemtrade/issues/1569#issuecomment-3616382945).

It allows the user to define a region (or regions) in config like

```
regions_with_warn_on_force_orders: ['ASIA']
```

That says: if the strategy order generator creates any orders for an instrument with region 'ASIA' that have force roll status, then a critical warning would be issued. With default setup, that would mean an email message - giving the user the option to either change the roll status or manually delete the instrument order. By default, the new config item is empty, so no change. 

The PR also refactors data object creation in `strategy_order_handling.py`, moving instantiation to `init()`