### PR TITLE
Reduce stack handler repeated log messages

### DIFF
--- a/sysbrokers/IB/client/ib_client.py
+++ b/sysbrokers/IB/client/ib_client.py
@@ -25,34 +25,6 @@ PACING_INTERVAL_SECONDS = 0.5
 
 STALE_SECONDS_ALLOWED_ACCOUNT_SUMMARY = 600
 
-IB_ERROR_TYPES = {
-    200: "ambiguous contract",
-    501: "already connected",
-    502: "can't connect",
-    503: "TWS need upgrading",
-    100: "Max messages exceeded",
-    102: "Duplicate ticker",
-    103: "Duplicate orderid",
-    104: "can't modify filled order",
-    105: "trying to modify different order",
-    106: "can't transmit orderid",
-    107: "can't transmit incomplete order",
-    109: "price out of range",
-    110: "tick size wrong for price",
-    122: "No request tag has been found for order",
-    123: "invalid conid",
-    133: "submit order failed",
-    134: "modify order failed",
-    135: "cant find order",
-    136: "order cant be cancelled",
-    140: "size should be an integer",
-    141: "price should be a double",
-    201: "order rejected",
-    202: "order cancelled",
-}
-
-IB_IS_ERROR = list(IB_ERROR_TYPES.keys())
-
 
 class ibClient(object):
     """
@@ -68,9 +40,6 @@ class ibClient(object):
             datetime.datetime.now()
             - datetime.timedelta(seconds=PACING_INTERVAL_SECONDS)
         )
-
-        # Add error handler
-        ibconnection.ib.errorEvent += self.error_handler
 
         self._ib_connnection = ibconnection
         self._log = log
@@ -95,43 +64,6 @@ class ibClient(object):
     @property
     def log(self):
         return self._log
-
-    def error_handler(
-        self, reqid: int, error_code: int, error_string: str, ib_contract: ibContract
-    ):
-        """
-        Error handler called from server
-        Needs to be attached to ib connection
-
-        :param reqid: IB reqid
-        :param error_code: IB error code
-        :param error_string: IB error string
-        :param contract: IB contract or None
-        :return: success
-        """
-
-        msg = "Reqid %d: %d %s for %s" % (
-            reqid,
-            error_code,
-            error_string,
-            str(ib_contract),
-        )
-
-        iserror = error_code in IB_IS_ERROR
-        if iserror:
-            # Serious requires some action
-            myerror_type = IB_ERROR_TYPES.get(error_code, "generic")
-            self.broker_error(msg=msg, myerror_type=myerror_type, log=self.log)
-
-        else:
-            # just a general message
-            self.broker_message(msg=msg, log=self.log)
-
-    def broker_error(self, msg, log, myerror_type):
-        log.warning(msg)
-
-    def broker_message(self, log, msg):
-        log.debug(msg)
 
     def refresh(self):
         self.ib.sleep(0.00001)

--- a/syslogging/filters.py
+++ b/syslogging/filters.py
@@ -10,13 +10,15 @@ class IBFilter(logging.Filter):
         super().__init__("ib_insync")
 
     def filter(self, record):
-        # if msg starts with 'Warning', then set the level to WARNING and allow
-        if record.msg.startswith("Warning"):
-            record.levelname = "WARNING"
-            record.levelno = 30
-            return True
-        # don't allow INFO or lower
-        if record.levelno < 25:
-            return False
+        # for all records with name starting 'ib_insync'
+        if record.name.startswith(self.name):
+            # if msg starts with 'Warning', then set the level to WARNING and allow
+            if record.msg.startswith("Warning"):
+                record.levelname = "WARNING"
+                record.levelno = 30
+                return True
+            # don't allow INFO or lower
+            if record.levelno < 25:
+                return False
         # otherwise allow
         return True

--- a/syslogging/filters.py
+++ b/syslogging/filters.py
@@ -1,0 +1,22 @@
+import logging
+
+
+class IBFilter(logging.Filter):
+    """
+    Custom log filter for 'ib-insync'. Should be added at handler level
+    """
+
+    def __init__(self):
+        super().__init__("ib_insync")
+
+    def filter(self, record):
+        # if msg starts with 'Warning', then set the level to WARNING and allow
+        if record.msg.startswith("Warning"):
+            record.levelname = "WARNING"
+            record.levelno = 30
+            return True
+        # don't allow INFO or lower
+        if record.levelno < 25:
+            return False
+        # otherwise allow
+        return True

--- a/syslogging/logger.py
+++ b/syslogging/logger.py
@@ -4,6 +4,7 @@ import socket
 import logging.config
 import syslogging
 from syslogging.adapter import *
+from syslogging.filters import IBFilter
 from syslogging.pyyaml_env import parse_config
 from syscore.fileutils import resolve_path_and_filename_for_package
 
@@ -83,7 +84,7 @@ def _configure_sim():
     print("Configuring sim logging")
     handler = logging.StreamHandler(stream=sys.stdout)
     handler.setLevel(logging.DEBUG)
-    logging.getLogger("ib_insync").setLevel(logging.WARNING)
+    handler.addFilter(IBFilter())
     logging.getLogger("arctic").setLevel(logging.INFO)
     logging.getLogger("matplotlib").setLevel(logging.INFO)
     logging.basicConfig(

--- a/syslogging/logging_prod.yaml
+++ b/syslogging/logging_prod.yaml
@@ -4,12 +4,16 @@ formatters:
   simple:
     format: '%(asctime)s %(levelname)s %(name)s %(message)s'
     datefmt: '%Y-%m-%d %H:%M:%S'
+filters:
+  ibFilter:
+    (): syslogging.filters.IBFilter
 handlers:
   console:
     class: logging.StreamHandler
     level: DEBUG
     stream: ext://sys.stdout
     formatter: simple
+    filters: [ibFilter]
   email:
     class: syslogging.handlers.PstSMTPHandler
     level: CRITICAL
@@ -20,9 +24,8 @@ handlers:
     port: 9020
     level: DEBUG
     formatter: simple
+    filters: [ibFilter]
 loggers:
-  ib_insync:
-    level: WARNING
   arctic:
     level: INFO
   matplotlib:

--- a/syslogging/logging_sim.yaml
+++ b/syslogging/logging_sim.yaml
@@ -4,15 +4,17 @@ formatters:
   simple:
     format: '%(asctime)s %(levelname)s %(name)s %(message)s'
     dateformat: '%Y-%m-%d %H:%M:%S'
+filters:
+  ibFilter:
+    (): syslogging.filters.IBFilter
 handlers:
   console:
     class: logging.StreamHandler
     level: DEBUG
     formatter: simple
     stream: ext://sys.stdout
+    filters: [ibFilter]
 loggers:
-  ib_insync:
-    level: WARNING
   arctic:
     level: INFO
   matplotlib:


### PR DESCRIPTION
Fix for #1570 

This change removes the custom error handler from `ibClient`. All those messages we receive direct from ib-insync's own logging, now that we are using Python logging. The only slight quirk is that some of ib_insync's messages have message starting 'Warning...', but have level of INFO. This change sets the level for those messages to WARNING, using a custom `logging.Filter`.

This change does not address the issue of trying to translate an IB instrument code into PST instrument code. That is because `ib_async` makes some changes to the error reporting logic, so I think it best to migrate first.

