### PR TITLE
fix error getting strategy name from user for Balance Trade when no positions

### DIFF
--- a/sysproduction/data/strategies.py
+++ b/sysproduction/data/strategies.py
@@ -1,5 +1,6 @@
 from sysdata.data_blob import dataBlob
 from syscore.constants import arg_not_supplied
+from syscore.exceptions import missingData
 from syscore.interactive.menus import print_menu_of_values_and_get_response
 from sysproduction.data.positions import diagPositions
 from sysproduction.data.optimal_positions import dataOptimalPositions
@@ -47,14 +48,15 @@ class diagStrategiesConfig(productionDataLayerGeneric):
 
 
 def get_list_of_strategies(data: dataBlob = arg_not_supplied, source="config") -> list:
-    if source == "config":
-        return get_list_of_strategies_from_config(data)
-    elif source == "positions":
-        return get_list_of_strategies_from_positions(data)
-    elif source == "optimal_positions":
-        return get_list_of_strategies_from_optimal_positions(data)
-    else:
+    handlers = {
+        "config": get_list_of_strategies_from_config,
+        "positions": get_list_of_strategies_from_positions,
+        "optimal_positions": get_list_of_strategies_from_optimal_positions,
+    }
+    if source not in handlers.keys():
         raise Exception("Source %s not recognised!" % source)
+
+    return handlers[source](data)
 
 
 def get_list_of_strategies_from_config(data: dataBlob = arg_not_supplied) -> list:
@@ -87,8 +89,19 @@ def get_valid_strategy_name_from_user(
     allow_all: bool = False,
     all_code: str = "ALL",
     source: str = "config",
-):
+    prompt: str = "Which strategy?",
+    backup_source: str = None,
+) -> str:
+    assert source != backup_source
+    print(prompt)
     all_strategies = get_list_of_strategies(data=data, source=source)
+    if not all_strategies and backup_source:
+        print(f"No strategies found using source '{source}', trying '{backup_source}'")
+        all_strategies = get_list_of_strategies(data=data, source=backup_source)
+
+    if not all_strategies:
+        raise missingData("No strategies found")
+
     if allow_all:
         default_strategy = all_code
     else:

--- a/sysproduction/interactive_order_stack.py
+++ b/sysproduction/interactive_order_stack.py
@@ -50,6 +50,7 @@ from sysexecution.orders.instrument_orders import (
 from sysexecution.algos.allocate_algo_to_order import get_list_of_algos
 from sysbrokers.IB.ib_connection import connectionIB
 from syscore.constants import arg_not_supplied
+from syscore.exceptions import missingData
 
 from sysobjects.contracts import futuresContract
 
@@ -199,17 +200,18 @@ def create_balance_trade(data):
 
     broker_order = get_broker_order_details_for_balance_trade(data)
 
-    print(broker_order)
-    ans = input("Are you sure? (Y/other)")
-    if ans != "Y":
-        return None
+    if broker_order:
+        print(broker_order)
+        ans = input("Are you sure? (Y/other)")
+        if ans != "Y":
+            return
 
-    stack_handler = stackHandlerCreateBalanceTrades(data)
+        stack_handler = stackHandlerCreateBalanceTrades(data)
 
-    stack_handler.create_balance_trade(broker_order)
+        stack_handler.create_balance_trade(broker_order)
 
 
-def get_broker_order_details_for_balance_trade(data: dataBlob) -> brokerOrder:
+def get_broker_order_details_for_balance_trade(data: dataBlob) -> brokerOrder | None:
     ans = true_if_answer_is_yes(
         "Auto close an existing position (if not, manually enter details)?"
     )
@@ -242,10 +244,15 @@ def get_broker_order_details_for_balance_trade(data: dataBlob) -> brokerOrder:
         "Commission", type_expected=float, allow_default=True, default_value=0.0
     )
 
-    strategy_name = get_valid_strategy_name_from_user(data=data, source="positions")
+    try:
+        strategy_name = get_valid_strategy_name_from_user(
+            data=data, source="positions", backup_source="config"
+        )
+    except missingData as md:
+        print(f"Problem getting strategy name: {md}\n")
+        return None
 
-    data_broker = dataBroker(data)
-    default_account = data_broker.get_broker_account()
+    default_account = data.config.get_element("broker_account")
     broker_account = get_input_from_user_and_convert_to_type(
         "Account ID",
         type_expected=str,


### PR DESCRIPTION
Fixes #1524 

- adds a prompt when requesting strategy from user
- for Balance trade, handles case where no strategy names found 
- for Balance trade, allows a backup 'config' source for strategy names 
- for Balance trade, get account ID from config instead of IB