### PR TITLE
Optimise parquet access

### DIFF
--- a/sysdata/data_blob.py
+++ b/sysdata/data_blob.py
@@ -1,9 +1,8 @@
-from copy import copy
+import copy
 
 from sysbrokers.IB.ib_connection import connectionIB
 from syscore.objects import get_class_name
 from syscore.constants import arg_not_supplied
-from syscore.fileutils import get_resolved_pathname
 from syscore.text import camel_case_split
 from sysdata.config.production_config import get_production_config, Config
 from sysdata.mongodb.mongo_connection import mongoDb
@@ -329,14 +328,19 @@ class dataBlob(object):
 
     @property
     def parquet_access(self) -> ParquetAccess:
-        return ParquetAccess(self.parquet_root_directory)
+        parquet_access = getattr(self, "_parquet_access", arg_not_supplied)
+        if parquet_access is arg_not_supplied:
+            parquet_access = ParquetAccess(self.parquet_root_directory)
+            self._parquet_access = parquet_access
+
+        return parquet_access
 
     @property
     def parquet_root_directory(self) -> str:
         path = self._parquet_store_path
         if path is arg_not_supplied:
             try:
-                path = get_parquet_root_directory(self.config)
+                path = self.config.get_element("parquet_store")
             except:
                 raise Exception("Need to define parquet_store in config to use parquet")
 
@@ -375,11 +379,6 @@ class dataBlob(object):
 
 
 source_dict = dict(arctic="db", mongo="db", csv="db", parquet="db", ib="broker")
-
-
-def get_parquet_root_directory(config):
-    path = config.get_element("parquet_store")
-    return get_resolved_pathname(path)
 
 
 def identifying_name(

--- a/sysdata/parquet/parquet_access.py
+++ b/sysdata/parquet/parquet_access.py
@@ -2,27 +2,30 @@ from pathlib import Path
 import pandas as pd
 from syscore.exceptions import missingFile
 from syscore.fileutils import (
-    files_with_extension_in_pathname,
+    files_with_extension_in_resolved_pathname,
     resolve_path_and_filename_for_package,
     get_resolved_pathname,
 )
-from pathlib import Path
-
-EXTENSION = "parquet"
 
 
 class ParquetAccess(object):
     def __init__(self, parquet_store_path: str):
-        self.parquet_store = get_resolved_pathname(parquet_store_path)
+        """
+        Initialises an instance of the ParquetAccess class responsible for handling
+        the location of a Parquet data store
+
+        :param parquet_store_path: path to the Parquet data store
+        :type parquet_store_path: str
+        """
+        self.accessor = LocalAccessor(parquet_store_path)
 
     def get_all_identifiers_with_data_type(self, data_type: str):
-        path = self._get_pathname_given_data_type(data_type)
-        return files_with_extension_in_pathname(path, extension=EXTENSION)
+        return self.accessor.identifiers_for_type(data_type)
 
     def does_identifier_with_data_type_exist(
         self, data_type: str, identifier: str
     ) -> bool:
-        filename = self._get_filename_given_data_type_and_identifier(
+        filename = self.accessor.get_filename_given_data_type_and_identifier(
             data_type=data_type, identifier=identifier
         )
         return Path(filename).exists()
@@ -30,7 +33,7 @@ class ParquetAccess(object):
     def delete_data_given_data_type_and_identifier(
         self, data_type: str, identifier: str
     ):
-        filename = self._get_filename_given_data_type_and_identifier(
+        filename = self.accessor.get_filename_given_data_type_and_identifier(
             data_type=data_type, identifier=identifier
         )
         try:
@@ -41,7 +44,7 @@ class ParquetAccess(object):
     def write_data_given_data_type_and_identifier(
         self, data_to_write: pd.DataFrame, data_type: str, identifier: str
     ):
-        filename = self._get_filename_given_data_type_and_identifier(
+        filename = self.accessor.get_filename_given_data_type_and_identifier(
             data_type=data_type, identifier=identifier
         )
         data_to_write.to_parquet(
@@ -51,21 +54,32 @@ class ParquetAccess(object):
     def read_data_given_data_type_and_identifier(
         self, data_type: str, identifier: str
     ) -> pd.DataFrame:
-        filename = self._get_filename_given_data_type_and_identifier(
+        filename = self.accessor.get_filename_given_data_type_and_identifier(
             data_type=data_type, identifier=identifier
         )
         return pd.read_parquet(filename)
 
-    def _get_filename_given_data_type_and_identifier(
+
+class LocalAccessor:
+    EXTENSION = "parquet"
+
+    def __init__(self, parquet_path: str):
+        self._base_path = get_resolved_pathname(parquet_path)
+
+    def identifiers_for_type(self, data_type: str):
+        path = self.get_pathname_given_data_type(data_type)
+        return files_with_extension_in_resolved_pathname(path, extension=self.EXTENSION)
+
+    def get_filename_given_data_type_and_identifier(
         self, data_type: str, identifier: str
     ):
-        path = self._get_pathname_given_data_type(data_type)
-        return resolve_path_and_filename_for_package(
-            path, separate_filename="%s.%s" % (identifier, EXTENSION)
+        path = self.get_pathname_given_data_type(data_type)
+        filename = resolve_path_and_filename_for_package(
+            path, separate_filename=f"{identifier}.{self.EXTENSION}"
         )
+        return filename
 
-    def _get_pathname_given_data_type(self, data_type: str):
-        root = self.parquet_store
-        path = Path(root, data_type)
+    def get_pathname_given_data_type(self, data_type: str):
+        path = Path(self._base_path, data_type)
         path.mkdir(parents=True, exist_ok=True)
         return str(path)


### PR DESCRIPTION
Fix for #1609 

- optimise ParquetAccess creation, one per dataBlob
- reduce number of path resolution calls
- ParquetAccess refactored to delegate file/path resolution, extendable to alternative implementations, eg cloud