### PR TITLE
Change log level from critical to warning

### DIFF
--- a/sysdata/production/broker_client_id.py
+++ b/sysdata/production/broker_client_id.py
@@ -87,7 +87,7 @@ class brokerClientIdData(baseData):
         :return:
         """
         client_id_list = self._get_list_of_clientids()
-        self.log.critical(
+        self.log.warning(
             "Clearing all broker client IDs: if anything still running will probably break!"
         )
         for client_id in client_id_list:


### PR DESCRIPTION
This could be debated, but here is my reasoning:

1. This is just the function doing what it is supposed to do.
2. If this is truly a critical operation, there should be an option to intervene before it gets to this point.
3. I do not want to to be notified every time this runs

There are 2 times when it runs:
- At machine startup (if using the provided crontab): no clients would be connected anyway
- Manually from interactive controls: the user has already been warned and asked to confirm



