### PR TITLE
Don't require a log server

### DIFF
--- a/syslogging/logger.py
+++ b/syslogging/logger.py
@@ -113,7 +113,9 @@ def _configure_prod(logging_config_file):
                 except BlockingIOError:
                     print(f"Log server detected OK at {host}:{port}")
                 except (ConnectionResetError, ConnectionRefusedError):
-                    print(f"Cannot connect to log server at {host}:{port}, is it running?")
+                    print(
+                        f"Cannot connect to log server at {host}:{port}, is it running?"
+                    )
                     raise
             logging.config.dictConfig(config)
             syslogging.logging_configured = True

--- a/syslogging/logger.py
+++ b/syslogging/logger.py
@@ -103,14 +103,18 @@ def _configure_prod(logging_config_file):
     if Path(config_path).exists():
         try:
             config = parse_config(path=config_path)
-            host, port = _get_log_server_config(config)
             try:
-                _check_log_server(host, port)
-            except BlockingIOError:
-                print(f"Log server detected OK at {host}:{port}")
-            except (ConnectionResetError, ConnectionRefusedError):
-                print(f"Cannot connect to log server at {host}:{port}, is it running?")
-                raise
+                host, port = _get_log_server_config(config)
+            except KeyError:
+                print("No log server configured")
+            else:
+                try:
+                    _check_log_server(host, port)
+                except BlockingIOError:
+                    print(f"Log server detected OK at {host}:{port}")
+                except (ConnectionResetError, ConnectionRefusedError):
+                    print(f"Cannot connect to log server at {host}:{port}, is it running?")
+                    raise
             logging.config.dictConfig(config)
             syslogging.logging_configured = True
         except Exception as exc:


### PR DESCRIPTION
The existing code requires a log server for production logging, and reverts to sim_logging if there isn't one configured.

This change will instead display a message that there is no log server configured, but still proceed to configure the production logging.