### PR TITLE
Generate critical log message when a process fails

### DIFF
--- a/syscontrol/run_process.py
+++ b/syscontrol/run_process.py
@@ -106,7 +106,9 @@ class processToRun(object):
             self._main_loop_over_methods()
             self._finish()
         except Exception:
-            self.log.critical(f"Process {self.process_name} failed!")
+            config = self.data.config
+            if config.get_element_or_default("log_failed_processes", False):
+                self.log.critical(f"Process {self.process_name} failed!")
             raise
 
     def _run_on_start(self):

--- a/syscontrol/run_process.py
+++ b/syscontrol/run_process.py
@@ -101,9 +101,13 @@ class processToRun(object):
         except processNotStarted:
             return None
 
-        self._run_on_start()
-        self._main_loop_over_methods()
-        self._finish()
+        try:
+            self._run_on_start()
+            self._main_loop_over_methods()
+            self._finish()
+        except Exception:
+            self.log.critical(f"Process {self.process_name} failed!")
+            raise
 
     def _run_on_start(self):
         self.data_control.start_process(self.process_name)

--- a/sysdata/config/defaults.yaml
+++ b/sysdata/config/defaults.yaml
@@ -98,6 +98,10 @@ execution_algos:
   algo_overrides:
     some_market_name_eg_IRON: sysexecution.algos.algo_market.algoMarket
 #
+# Generate a critical log message when a process fails
+# Defaults to false to avoid duplicate notifications if the monitor app is used
+log_failed_processes: False
+#
 #           BACKTESTING STUFF
 #
 # Raw data


### PR DESCRIPTION
Take this as a suggestion.

Currently if a process fails unexpectedly, it is more or less silent.  There is a stack trace in the logs, and you could see in the status report if you're paying attention.

This generates a critical log message, which in turn will generate an email notification if properly configured.

I have found this useful for years, but since it is more of a personal preference than a bug fix, I never bothered to submit a PR.

It could be made configurable, but IMO if you are already getting email notifications, you should definitely want this one.  If you don't have emails configured, it won't bother you.