### PR TITLE
[SUPERSEDED BY #1630–#1633] Add non-interactive auto roll status job

### DIFF
--- a/docs/auto-roll-status.md
+++ b/docs/auto-roll-status.md
@@ -1,0 +1,500 @@
+<!--
+Copyright 2026 Google LLC
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+# Automated Roll Status
+
+`run_auto_roll_status` is a non-interactive daily process that updates futures
+contract roll states. It is intended to run after multiple/adjusted prices are
+updated and before the stack handler, so roll decisions use fresh price data.
+
+It plugs into the `processToRun` framework — same process locking, start/stop
+window, dashboard monitoring, and MongoDB finish-status tracking as the other
+production jobs. The decision logic is shared with `interactive_update_roll_status`
+so the interactive "automatic" cycle mode and the non-interactive job arrive at
+the same answers from the same inputs.
+
+The job is shipped opt-in: the crontab line and the `control_config.yaml`
+entries exist but are commented out. Uncomment them (or override in
+`private_control_config.yaml`) to schedule it.
+
+For motivation and a longer narrative writeup, see
+[On a roll state — the auto-roll system](https://managedfutures.substack.com/p/on-a-roll-state-the-auto-roll-system).
+
+---
+
+## Roll states
+
+Each instrument has a roll state stored in the database. The state machine is
+defined in `sysobjects/production/roll_state.py`:
+
+| State | Meaning |
+|---|---|
+| `No_Roll` | Normal trading. Only trade the priced (near) contract. |
+| `Passive` | Allow natural roll: close trades in priced contract, open in forward. |
+| `Force` | Force roll ASAP using a spread order. |
+| `Force_Outright` | Force roll ASAP using two separate outright orders. |
+| `Roll_Adjusted` | Roll the adjusted price series from priced to forward contract. Automatically returns to `No_Roll` on success. |
+| `Close` | Close position in the near contract only (no forward leg). |
+| `No_Open` | Near expiry but forward not liquid. No new opening trades; existing position can still be closed. |
+
+### Transition matrix
+
+Allowable transitions depend on both the current state and whether a position
+is held in the priced contract (`0` suffix = no position; `1` suffix = position
+held):
+
+| Current state + position | Allowable next states |
+|---|---|
+| `No_Roll0` | Roll_Adjusted, Passive, No_Roll, No_Open |
+| `No_Roll1` | Passive, Force, Force_Outright, No_Roll, Close, No_Open |
+| `Passive0` | Roll_Adjusted, Passive, No_Roll, No_Open |
+| `Passive1` | Force, Force_Outright, Passive, No_Roll, Close, No_Open |
+| `Force0` | Roll_Adjusted, Passive |
+| `Force1` | Force, Force_Outright, Passive, No_Roll, Close, No_Open |
+| `Force_Outright0` | Roll_Adjusted, Passive |
+| `Force_Outright1` | Force, Force_Outright, Passive, No_Roll, Close, No_Open |
+| `Close0` | Roll_Adjusted, Passive |
+| `Close1` | Close, Force, Force_Outright, Passive, No_Roll, No_Open |
+| `Roll_Adjusted0` | No_Roll |
+| `Roll_Adjusted1` | Roll_Adjusted |
+| `No_Open0` | Roll_Adjusted, Passive, No_Open |
+| `No_Open1` | Close, Force, Force_Outright, Passive, No_Roll |
+
+`No_Open0` deliberately does **not** allow `No_Roll` — the instrument stays in
+`No_Open` until the forward becomes liquid (→ `Roll_Adjusted`) or a position is
+opened (→ `No_Open1`).
+
+---
+
+## Decision logic
+
+Each instrument runs through `process_instrument_roll_status`, which applies a
+small set of escalation checks before delegating to `suggest_roll_state_for_instrument`
+for the normal liquidity/timing logic. A diagnostic log line is emitted before
+every decision recording the priced contract, its actual expiry, the priced-
+contract position, roll/expiry timing, and all current DB contract positions
+for the instrument.
+
+### Stage 0 — stuck-Force escalation
+
+If the current state is `Force`, a position is held, and the state has been
+`Force` for ≥ `force_roll_max_trading_days` trading days without rolling, the
+instrument is escalated to `Force_Outright` and the function returns. This
+handles spread orders that cannot execute because the spread tick data is
+missing or the spread leg is illiquid on the broker.
+
+The check requires a Force timestamp in the database. If the state was set
+through a path that did not record a timestamp, the escalation is skipped.
+
+### Stage 1 — expiry escalation
+
+If `days_until_expiry < near_expiry_days` and a position is still held, the
+state is forced to `Force` regardless of any other input. `Passive` rolling can
+no longer work once the priced contract stops accepting opening orders, and
+forcing earlier (`< near_expiry_days`, default 10) gives the stack handler time
+to execute the spread roll before the contract disappears.
+
+`Force` is always a valid transition when a position is held, so this path
+never hits the invalid-transition guard. The override is logged at CRITICAL so
+it surfaces in the email digest.
+
+### Stage 1.5 — late-roll escalation (inside `suggest`)
+
+If a position is held and the desired roll date has passed (`days_until_roll <
+0`), urgency is never downgraded:
+
+- Currently `Force`, `Force_Outright` or `Close`: hold it.
+- Anything else: escalate to `Force`.
+
+This runs before the normal liquidity/timing logic so the bounded passive
+window check cannot interpret negative values as "early passive".
+
+### Stage 1.75 — Roll_Adjusted orphan-position guard
+
+After normal suggestion logic runs but before the state is written, the
+process scans **all** current DB contract positions for the instrument. If the
+suggested state is `Roll_Adjusted` and any non-zero DB position maps to an
+actual expiry inside `near_expiry_days`, the transition is blocked, the
+instrument is left unchanged, and a CRITICAL alert is emitted.
+
+This catches the case where the priced contract has rolled forward in metadata
+(`position_priced_contract == 0`) but a live position remains in an
+expiring non-priced leg. The guard is deliberately conservative: it does not
+pick a replacement state because the correct next step depends on
+broker/DB reconciliation, which a human needs to drive.
+
+### Stage 2 — normal logic
+
+```
+1. Priced contract expired (or any key contract expired) and no position
+   and auto_roll_expired=True?
+   → Roll_Adjusted  (roll regardless of liquidity)
+
+2. Forward liquid?
+   a. No position → Roll_Adjusted
+   b. Position held, far from roll date → Passive
+   c. Position held, close to roll date → default_roll_state_if_undecided
+                                          (Force / Force_Outright / Close / Ask)
+
+3. Forward illiquid:
+   a. Position held + within passive window (0 <= days_until_roll < passive_start_days)
+      + forward has any volume?
+      → Passive  (start natural migration before forced roll)
+   b. Close to roll date (< near_expiry_days)?
+      → No_Open
+   c. Far from roll date:
+      → No_Roll  IF allowable from current state
+      → current state  OTHERWISE  (e.g. No_Open0 stays No_Open)
+```
+
+The expired + position case is handled entirely by Stage 1 — Stage 2 is never
+reached for it.
+
+### Liquidity test
+
+The forward contract is **liquid** when either:
+
+- `relative_volume > auto_roll_if_relative_volume_higher_than`, or
+- `relative_volume > min_relative_volume` AND `absolute_forward_volume > min_absolute_volume`
+
+where `relative_volume = forward_volume / priced_volume`.
+
+---
+
+## Configuration
+
+Parameters live under `roll_status_auto_update` in `defaults.yaml` (or your
+override in `private_config.yaml`):
+
+```yaml
+roll_status_auto_update:
+  # Relative volume threshold: if forward/priced > this, treat as liquid
+  # regardless of absolute volume.
+  auto_roll_if_relative_volume_higher_than: 1.0
+
+  # Combined threshold: both must be exceeded for forward to be considered liquid.
+  min_relative_volume: 0.01
+  min_absolute_volume: 100
+
+  # Days before priced-contract expiry at which:
+  #   - No_Roll → No_Open (if forward illiquid and position is held)
+  #   - Passive → default_roll_state_if_undecided (if forward liquid and position held)
+  #   - any state → Force (Stage 1 expiry escalation when position is held)
+  near_expiry_days: 10
+
+  # What to do when liquid + position + close to roll.
+  # One of: Force, Force_Outright, Close, or "Ask" (interactive only —
+  # non-interactive job auto-resolves Ask to Force and logs CRITICAL).
+  default_roll_state_if_undecided: Force
+
+  # Roll adjusted prices when the priced contract has expired and no position
+  # is held. Also covers expired carry/forward contracts via the same flag.
+  auto_roll_expired: true
+
+  # Days before the desired roll date at which a held position starts passive
+  # rolling, provided the forward has *some* volume. Bounded: negative values
+  # do not count as "early passive" — they fall under late-roll escalation.
+  passive_start_days: 30
+
+  # Max trading days a Force state may persist without rolling before the
+  # non-interactive job escalates to Force_Outright.
+  force_roll_max_trading_days: 2
+```
+
+---
+
+## Safety features
+
+### Stuck-Force escalation
+
+If an instrument has been in `Force` for more than `force_roll_max_trading_days`
+trading days without rolling, the job escalates to `Force_Outright` and logs at
+CRITICAL:
+
+```
+CRITICAL: FORCE ROLL STUCK for <code>: In Force state for 3 trading days
+(threshold: 2) without completing roll.
+Escalating to Force_Outright to execute outright orders instead of spread.
+```
+
+Trading days are counted as weekdays since the Force timestamp was recorded.
+If no timestamp exists, escalation is skipped.
+
+### Expiry escalation
+
+If the priced contract is within `near_expiry_days` of expiry and a position
+is still held, the state is forced to `Force` regardless of suggestion. Logged
+at CRITICAL.
+
+### Transition validation
+
+Before applying any state change, the proposed transition is checked against
+the allowable matrix. Invalid transitions are logged at CRITICAL and skipped —
+no change is made, preventing the database from drifting into an inconsistent
+state:
+
+```
+CRITICAL: INVALID TRANSITION for <code>: Cannot change from No_Open to No_Roll (position=0).
+Allowable transitions: ['Roll_Adjusted', 'Passive', 'No_Open']. Skipping — manual intervention needed.
+```
+
+### `Ask` auto-resolution
+
+If `default_roll_state_if_undecided` is `"Ask"` (intended for interactive use),
+the non-interactive job cannot prompt. It auto-resolves to `Force` (the safest
+automated choice) and logs at CRITICAL so the operator sees the misconfiguration
+and can change the setting.
+
+### Roll_Adjusted forward-fill
+
+The job rolls adjusted prices with `allow_auto_forward_fill=True`, so it never
+blocks on stdin. If the normal roll calculation fails, it automatically retries
+with forward-fill before giving up and logging a warning.
+
+### Roll_Adjusted orphan-position guard
+
+Before applying `Roll_Adjusted`, all current DB contract positions for the
+instrument are scanned. If any non-zero DB position maps to an actual expiry
+inside `near_expiry_days`, the transition is blocked and logged at CRITICAL:
+
+```
+CRITICAL: ROLL_ADJUSTED BLOCKED for <code>: expiring DB contract positions exist
+despite zero priced-contract position: [...].
+Leaving roll state unchanged and requiring manual/Force roll review.
+```
+
+The guard is deliberately conservative — it leaves the instrument unchanged
+rather than guessing a replacement state, because the correct next step depends
+on broker/DB reconciliation.
+
+### Exception isolation
+
+Exceptions during processing of any single instrument are caught, logged at
+CRITICAL, and the loop continues. One broken instrument never blocks the rest
+of the roll cycle.
+
+### Missing-contract tolerance during selection
+
+`check_if_any_key_contract_has_expired` (used to widen the auto-cycle
+selection) reads each key contract (carry, priced, forward) from the contracts
+DB. Two distinct failure modes are handled:
+
+- **Forward not yet sampled.** A fresh `Roll_Adjusted` advances the forward
+  slot in the multiple-prices chain *before* `update_sampled_contracts` writes
+  the new contract. The next auto-roll invocation would otherwise raise
+  `ContractNotFound` and exit unhandled, leaving `currently_running=True` in
+  the process control DB and triggering a spurious "crashed" alert from the
+  system monitor. The helper now treats `ContractNotFound` for the forward
+  leg as not-expired (logged at DEBUG) and continues.
+
+- **Missing carry or priced contract.** Carry and priced legs should always be
+  sampled; a missing one implies a delisted contract, a manual DB deletion, or
+  a stale/mistyped multiple-prices entry. The helper logs at CRITICAL and
+  skips that leg, so visibility is preserved without crashing the run.
+
+---
+
+## Logging
+
+Every state change is logged with a `reason=` field identifying which decision
+branch selected the new state:
+
+```
+Auto-updating roll state for <code>: Force -> Force_Outright
+reason=force_roll_stuck
+position=-1 days_until_expiry=27 days_to_roll=-8 rel_vol=0.0828 fwd_vol=94
+```
+
+| `reason` | Meaning |
+|---|---|
+| `expiry_escalation` | Stage 1 override: contract near/past expiry with position held |
+| `force_roll_stuck` | Stage 0 override: Force spread order stuck for too many trading days |
+| `late_roll_escalation` | Stage 1.5: past desired roll date with position held |
+| `early_passive` | Within passive start window, forward has some volume |
+| `forward_illiquid_close_to_roll` | Forward illiquid, close to roll date → No_Open |
+| `roll_adjusted` | No position, forward liquid or expired |
+| `expired_key_contract_auto_roll` | Carry/key contract expired, no position, auto_roll_expired=True |
+| `no_roll` | Forward illiquid, far from roll date |
+| `auto_resolved_ask` | Config says `Ask` but running non-interactively |
+| `default` | None of the above matched |
+
+A diagnostic log line is emitted **before** each decision, recording priced
+contract id, actual expiry, priced-contract position, `days_until_expiry`,
+`days_until_roll`, and all current DB contract positions. This line is always
+present, even when no state change is made.
+
+---
+
+## Scheduling
+
+The recommended schedule is a **single nightly run**, after
+`run_daily_update_multiple_adjusted_prices` so roll decisions use today's
+forward-contract volume and liquidity:
+
+```cron
+# Nightly full pass — must run after run_daily_update_multiple_adjusted_prices for fresh data.
+30 23 * * 1-5 $SCRIPT_PATH/run_auto_roll_status >> $ECHO_PATH/run_auto_roll_status.txt 2>&1
+```
+
+One run per day is sufficient: the job is idempotent, and a single late-evening
+pass evaluates every instrument with the day's full volume data — which is
+what `auto_roll_if_relative_volume_higher_than`, `min_relative_volume`, and
+`min_absolute_volume` are testing against.
+
+### Twice-daily setups
+
+A morning safety pass can close the gap between the previous nightly run and
+the next morning's expiry checker (`run_daily_fx_and_contract_updates` at
+07:05). **Do not simply add a second cron line**: the framework's wait loop
+will hold the morning instance in `_start_or_wait` until the configured
+`process_configuration_start_time` is reached, at which point it races with
+the evening cron. The morning instance is the one that crashed in production
+when both fired in the same minute, leaving the process-control record in
+`currently_running=True`.
+
+To run a real morning pass, widen the configured window so the morning
+instance has its own slot:
+
+```yaml
+# syscontrol/control_config.yaml (or private_control_config.yaml)
+process_configuration_start_time:
+  run_auto_roll_status: '07:00'   # was '23:30' — now allows a morning slot
+process_configuration_stop_time:
+  run_auto_roll_status: '23:55'
+```
+
+Then both cron lines can fire:
+
+```cron
+00 07 * * 1-5 $SCRIPT_PATH/run_auto_roll_status >> $ECHO_PATH/run_auto_roll_status.txt 2>&1
+30 23 * * 1-5 $SCRIPT_PATH/run_auto_roll_status >> $ECHO_PATH/run_auto_roll_status.txt 2>&1
+```
+
+If `process_configuration_start_time` remains at `'23:30'` (the shipped
+default), keep only the evening cron line.
+
+The look-ahead window used to select instruments is:
+
+```python
+days_ahead = max(passive_start_days, near_expiry_days)
+```
+
+so an instrument that needs early-passive rolling is still included even
+before it enters the `near_expiry_days` window.
+
+---
+
+## Manual override
+
+When the job logs CRITICAL and skips an instrument, drive the fix interactively:
+
+```bash
+python -m sysproduction.interactive_update_roll_status
+```
+
+Pick option 1 ("Manually input instrument codes") and enter the code. The tool
+shows the current state, allowable transitions, and prompts for the correct
+next state.
+
+---
+
+## Common scenarios
+
+### Contract expiring with a position held — expiry escalation
+
+`days_until_expiry < near_expiry_days` (default: 10) and the priced position is
+non-zero. The job overrides any other suggested state and sets the instrument
+to `Force`. The stack handler picks up a spread roll order on its next cycle.
+
+A CRITICAL email is expected. Check the reconcile report the next day to
+confirm the roll completed. If the instrument is already locked by the stack
+handler, unlock it via `interactive_order_stack`, post a balance trade to
+reconcile, then set `Force` manually.
+
+### Position held past the desired roll date — late-roll escalation
+
+`days_until_roll < 0` with a position held, but `days_until_expiry` is still
+≥ `near_expiry_days`. Stage 1.5 fires before normal logic. If the instrument
+is already in `Force`, `Force_Outright`, or `Close`, it stays there — no
+de-escalation. Anything else is escalated to `Force`.
+
+If the forward is illiquid, the stuck-Force escalation can subsequently promote
+the instrument to `Force_Outright` after `force_roll_max_trading_days`. For
+instruments with consistently poor spread markets, override per-instrument:
+
+```yaml
+roll_status_auto_update_overrides:
+  <CODE>:
+    default_roll_state_if_undecided: Force_Outright
+    force_roll_max_trading_days: 1
+```
+
+### `No_Open` with no position, forward still illiquid
+
+The position was closed, but the forward is still illiquid and the roll date
+is approaching. `No_Open0` does not allow `No_Roll`, so the job falls back to
+the current state (`No_Open`) silently. The instrument stays in `No_Open` until
+the forward becomes liquid (→ `Roll_Adjusted`) or a new position is opened.
+
+### Roll_Adjusted needed but forward prices are missing
+
+The roll retries with forward-fill automatically. If that also fails, a warning
+is logged and the state is left unchanged.
+
+### Forward contract just rolled but not yet sampled
+
+Immediately after a `Roll_Adjusted` succeeds, the multiple-prices chain
+references a new forward contract that `update_sampled_contracts` has not yet
+written to the contracts DB. The selection helper handles this silently
+(DEBUG log only) — no action needed. The contract will be sampled by the next
+`run_daily_fx_and_contract_updates` cycle.
+
+If you see a CRITICAL log such as
+`Key contract <code>/<id> (...c|...p) referenced by multiple-prices but
+missing from contracts DB`, it is **not** the post-roll case — it indicates a
+delisted contract, a manual DB deletion, or a corrupt multiple-prices entry,
+and needs investigation.
+
+### Roll_Adjusted blocked by an expiring non-priced DB leg
+
+The suggested state is `Roll_Adjusted` (usually because the priced contract has
+no position), but another DB contract position for the same instrument is
+non-zero and near actual expiry. The job leaves the roll state unchanged and
+emits CRITICAL. Reconcile DB and broker positions before acting: balance out a
+genuinely orphaned DB leg, or drive a manual/Force roll if the broker still
+holds the position.
+
+### `default_roll_state_if_undecided` is `"Ask"`
+
+Change it to `Force` (or `Force_Outright` / `Close`) in your config:
+
+```yaml
+roll_status_auto_update:
+  default_roll_state_if_undecided: Force
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `sysproduction/run_auto_roll_status.py` | Entry point, `processToRun` integration, escalations, orphan-position guard |
+| `sysproduction/interactive_update_roll_status.py` | Shared suggestion logic: `suggest_roll_state_for_instrument`, `modify_roll_state` |
+| `sysobjects/production/roll_state.py` | `RollState` enum and transition matrix |
+| `tests/test_auto_roll_status.py` | Unit tests for suggestion branches, escalations, transitions |
+| `sysdata/config/defaults.yaml` | Default `roll_status_auto_update` parameters |

--- a/docs/production.md
+++ b/docs/production.md
@@ -1515,6 +1515,7 @@ These are listed here for convenience, but more documentation is given below in 
 - run_systems: Runs [update_system_backtests](#run-updated-backtest-systems-for-one-or-more-strategies): Runs a backtest to decide what optimal positions are required
 - run_strategy_order_generator: Runs [update_strategy_orders](#generate-orders-for-each-strategy): Creates trades based on the output of run_systems
 - [run_stack_handler](#execute-orders): Executes trades placed on the stack by run_strategy_order_generator
+- run_auto_roll_status: Runs [auto_roll_status](#automated-roll-status-non-interactive): Non-interactive daily update of roll states. Opt-in (disabled in the default schedule)
 
 
 ## Core production system components
@@ -1974,6 +1975,31 @@ I recommend that you run a roll report after doing this to see what state things
 #### Cycle through instrument codes automatically, auto decide when to roll, automatically roll
 
 This is exactly like the previous option, except that if a decision is made to roll adjusted prices, this will happen automatically without user confirmation.
+
+### Automated roll status (non-interactive)
+(Daily, opt-in)
+
+`run_auto_roll_status` is a non-interactive daily process that applies the same suggestion logic as the fully-automatic mode of `interactive_update_roll_status`, but without any user prompts. It is intended to run after multiple/adjusted prices are updated and before the stack handler, so roll decisions use fresh price data.
+
+It is **disabled by default** — there is no crontab entry shipped active, and `control_config.yaml` does not start it automatically. To enable it, uncomment the relevant lines in `sysproduction/linux/crontab` and `syscontrol/control_config.yaml` (or override in your `private_control_config.yaml`).
+
+Python:
+```python
+from sysproduction.run_auto_roll_status import run_auto_roll_status
+run_auto_roll_status()
+```
+
+Linux script:
+```
+. $SCRIPT_PATH/run_auto_roll_status
+```
+
+The job reuses `autoRollParameters` (same defaults as the interactive flow) and `suggest_roll_state_for_instrument`, so interactive and automatic decisions stay consistent. It also performs two safety escalations on top of the interactive logic:
+
+- **Expiry escalation**: if the priced contract is within `near_expiry_days` and a position is still held, the state is forced to `Force` regardless of the suggested state. This closes the gap where a position would otherwise sit in `Passive` against an expired contract.
+- **Stuck-Force escalation**: if the instrument has been in `Force` for more than `force_roll_max_trading_days` without rolling (e.g., illiquid spread on the broker), the state is escalated to `Force_Outright`.
+
+See [docs/auto-roll-status.md](auto-roll-status.md) for the full state-transition matrix, configuration knobs, and operational guidance.
 
 ## Menu driven interactive scripts
 

--- a/syscontrol/control_config.yaml
+++ b/syscontrol/control_config.yaml
@@ -10,6 +10,8 @@ process_configuration_start_time:
   run_backups: '20:15'
   run_cleaners: '20:20'
   run_reports: '20:25'
+  # Opt-in: see docs/auto-roll-status.md. Uncomment to enable.
+  #run_auto_roll_status: '23:30'
 process_configuration_stop_time:
   default: '23:50'
   run_strategy_order_generator: '23:50'
@@ -22,6 +24,8 @@ process_configuration_stop_time:
   run_backups: '23:50'
   run_cleaners: '23:50'
   run_reports: '23:50'
+  # Opt-in: see docs/auto-roll-status.md. Uncomment together with the start time above.
+  #run_auto_roll_status: '23:55'
 ## Examples of passing arguments
 #arguments:
 #  run_daily_prices_updates:
@@ -131,6 +135,11 @@ process_configuration_methods:
       max_executions: 1
     clean_log_files:
       max_executions: 1
+  # Opt-in: non-interactive automated roll status. See docs/auto-roll-status.md.
+  # Uncomment together with the start/stop times above to enable.
+  #run_auto_roll_status:
+  #  update_auto_roll_status:
+  #    max_executions: 1
 # You need to create an entry in private control config that looks like this for each strategy
 #process_configuration_methods:
 #  run_systems:

--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -13,6 +13,7 @@ from syscore.interactive.input import (
 )
 from syscore.interactive.menus import print_menu_of_values_and_get_response
 from syscore.constants import named_object, status, success, failure
+from syscore.exceptions import ContractNotFound
 from syscore.interactive.display import (
     print_with_landing_strips_around,
     landing_strip,
@@ -40,7 +41,7 @@ from sysproduction.reporting.data.rolls import volume_contracts_in_forward_contr
 
 from sysproduction.data.positions import diagPositions, updatePositions
 from sysproduction.data.controls import updateOverrides, dataTradeLimits
-from sysproduction.data.contracts import dataContracts
+from sysproduction.data.contracts import dataContracts, FORWARD_SUFFIX
 from sysproduction.data.prices import diagPrices, get_valid_instrument_code_from_user
 
 from sysproduction.reporting.data.rolls import (
@@ -97,6 +98,7 @@ class RollDataWithStateReporting(object):
     relative_volume: float
     absolute_forward_volume: int
     days_until_expiry: int
+    any_key_contract_expired: bool = False
 
     @property
     def original_roll_status_as_string(self):
@@ -225,7 +227,11 @@ def get_days_ahead_to_consider_when_auto_cycling() -> int:
 
 
 def get_list_of_instruments_to_auto_cycle(data: dataBlob, days_ahead: int = 10) -> list:
-    diag_prices = diagPrices()
+    """
+    Returns instruments whose priced contract expires within days_ahead days,
+    or whose carry/forward contract has already expired.
+    """
+    diag_prices = diagPrices(data)
     list_of_potential_instruments = (
         diag_prices.get_list_of_instruments_in_multiple_prices()
     )
@@ -237,28 +243,78 @@ def get_list_of_instruments_to_auto_cycle(data: dataBlob, days_ahead: int = 10) 
         )
     ]
 
-    print_with_landing_strips_around(
-        "Identified following instruments that are near expiry %s"
-        % str(instrument_list)
-    )
-
     return instrument_list
 
 
 def include_instrument_in_auto_cycle(
     data: dataBlob, instrument_code: str, days_ahead: int = 10
 ) -> bool:
-    days_until_expiry = days_until_earliest_expiry(data, instrument_code)
-    return days_until_expiry <= days_ahead
+    """
+    Returns True if the instrument should be included in the auto-cycle check.
 
-
-def days_until_earliest_expiry(data: dataBlob, instrument_code: str) -> int:
+    Keys off ``days_until_price_expiry`` so the selection criterion matches the
+    escalation check used downstream by ``process_instrument_roll_status``.
+    Also includes instruments where any current key contract (carry, priced or
+    forward) has already expired, so an expired carry leg is not missed just
+    because the priced contract is still beyond the look-ahead window.
+    """
     data_contracts = dataContracts(data)
-    carry_days = data_contracts.days_until_carry_expiry(instrument_code)
-    roll_days = data_contracts.days_until_roll(instrument_code)
-    price_days = data_contracts.days_until_price_expiry(instrument_code)
+    days_until_expiry = data_contracts.days_until_price_expiry(instrument_code)
+    if days_until_expiry <= days_ahead:
+        return True
 
-    return min([carry_days, roll_days, price_days])
+    return check_if_any_key_contract_has_expired(
+        data=data, instrument_code=instrument_code
+    )
+
+
+def check_if_any_key_contract_has_expired(
+    data: dataBlob, instrument_code: str
+) -> bool:
+    """
+    Returns True if any current key contract has expired.
+
+    Key contracts are the carry/priced/forward contracts currently referenced
+    by the multiple-price series. Selecting on this matches the invariant that
+    ``update_sampled_contracts`` enforces, so an expired carry leg is caught
+    by auto-roll even if the priced contract is still healthy.
+    """
+    data_contracts = dataContracts(data)
+    labelled_contracts = data_contracts.get_labelled_dict_of_current_contracts(
+        instrument_code
+    )
+    key_contract_ids = labelled_contracts["contracts"]
+    key_contract_labels = labelled_contracts["labels"]
+
+    for contract_id, label in zip(key_contract_ids, key_contract_labels):
+        contract = futuresContract(instrument_code, contract_id)
+        try:
+            actual_contract = data_contracts.get_contract_from_db(contract)
+        except ContractNotFound:
+            # A fresh Roll_Adjusted advances the forward slot in the multiple-prices
+            # chain before update_sampled_contracts has populated the new contract,
+            # so an unsampled FORWARD is expected and cannot have expired. Treat
+            # missing carry/priced contracts as alert-worthy: they should always
+            # exist, and silently skipping them would mask a delisted contract or
+            # corrupt multiple-prices entry.
+            if label.endswith(FORWARD_SUFFIX):
+                data.log.debug(
+                    "Forward contract %s/%s not yet sampled in DB; "
+                    "treating as not-expired for auto-roll selection"
+                    % (instrument_code, contract_id)
+                )
+                continue
+            data.log.critical(
+                "Key contract %s/%s (%s) referenced by multiple-prices but missing "
+                "from contracts DB — investigate (delisted? manually deleted? "
+                "stale multiple-prices entry?). Skipping expiry check for this leg."
+                % (instrument_code, contract_id, label)
+            )
+            continue
+        if actual_contract.expired():
+            return True
+
+    return False
 
 
 @dataclass
@@ -269,6 +325,8 @@ class autoRollParameters:
     near_expiry_days: int
     default_roll_state_if_undecided: RollState
     auto_roll_expired: bool
+    passive_start_days: int = 30
+    force_roll_max_trading_days: int = 2
 
 
 ASK_FOR_STATE = "Ask"
@@ -302,6 +360,8 @@ def get_auto_roll_parameters_potentially_using_default(
         "default_roll_state_if_undecided"
     ]
     auto_roll_expired = default_parameters["auto_roll_expired"]
+    passive_start_days = default_parameters.get("passive_start_days", 30)
+    force_roll_max_trading_days = default_parameters.get("force_roll_max_trading_days", 2)
 
     if use_default:
         pass
@@ -346,6 +406,15 @@ def get_auto_roll_parameters_potentially_using_default(
             "Automatically roll adjusted prices when a priced contract has expired and no position?"
         )
 
+    # Convert string to RollState enum if needed
+    if isinstance(default_roll_state_if_undecided, str):
+        if default_roll_state_if_undecided == ASK_FOR_STATE:
+            # Keep as string "Ask" for later comparison
+            pass
+        else:
+            # Convert string to RollState enum
+            default_roll_state_if_undecided = RollState[default_roll_state_if_undecided]
+
     auto_parameters = autoRollParameters(
         min_absolute_volume=min_absolute_volume,
         min_relative_volume=min_relative_volume,
@@ -353,6 +422,8 @@ def get_auto_roll_parameters_potentially_using_default(
         auto_roll_if_relative_volume_higher_than=auto_roll_if_relative_volume_higher_than,
         near_expiry_days=near_expiry_days,
         auto_roll_expired=auto_roll_expired,
+        passive_start_days=passive_start_days,
+        force_roll_max_trading_days=force_roll_max_trading_days,
     )
 
     return auto_parameters
@@ -456,9 +527,25 @@ def suggest_roll_state_for_instrument(
     expired_and_auto_rolling_expired = check_if_expired_and_auto_rolling_expired(
         roll_data=roll_data, auto_parameters=auto_parameters
     )
+    key_contract_expired_and_auto_rolling_expired = (
+        roll_data.any_key_contract_expired and auto_parameters.auto_roll_expired
+    )
 
-    if expired_and_auto_rolling_expired and no_position_held:
-        ## contract expired so roll regardless of liquidity
+    # Late-roll escalation: a position is held and the desired roll date has
+    # already passed. Never downgrade urgency in this state — if we're already
+    # in Force, Force_Outright or Close, hold it; otherwise escalate to Force.
+    past_desired_roll_date = roll_data.days_until_roll < 0
+    if past_desired_roll_date and not no_position_held:
+        current_state = roll_data.original_roll_status
+        if current_state in (RollState.Force, RollState.Force_Outright, RollState.Close):
+            return current_state
+        return RollState.Force
+
+    if (
+        expired_and_auto_rolling_expired
+        or key_contract_expired_and_auto_rolling_expired
+    ) and no_position_held:
+        ## priced/key contract expired so roll regardless of liquidity
         return RollState.Roll_Adjusted
 
     if forward_liquid:
@@ -476,6 +563,20 @@ def suggest_roll_state_for_instrument(
                 return RollState.Passive
     else:
         # forward illiquid
+        # Early passive: if a position is held and we are inside the passive
+        # start window with any forward volume, go Passive to let the position
+        # migrate naturally before we have to force.
+        if not no_position_held:
+            within_passive_window = check_if_within_passive_start_window(
+                roll_data=roll_data, auto_parameters=auto_parameters
+            )
+            forward_has_some_volume = (
+                roll_data.relative_volume > 0
+                and roll_data.absolute_forward_volume > 0
+            )
+            if within_passive_window and forward_has_some_volume:
+                return RollState.Passive
+
         if getting_close_to_desired_roll_date:
             ## forward illiquid and getting close
             # We don't want to trade the forward - it's not liquid yet.
@@ -486,7 +587,14 @@ def suggest_roll_state_for_instrument(
             return RollState.No_Open
         else:
             ## forward illiquid and miles away. Don't roll yet.
-            return RollState.No_Roll
+            # No_Roll is not always a valid transition from the current state
+            # (e.g. No_Open0 only permits Roll_Adjusted / Passive / No_Open).
+            # Fall back to the current state when No_Roll is not allowable.
+            allowable = roll_data.allowable_roll_states_as_list_of_str
+            if RollState.No_Roll.name in allowable:
+                return RollState.No_Roll
+            else:
+                return roll_data.original_roll_status
 
 
 def check_if_forward_liquid(
@@ -511,6 +619,22 @@ def check_if_forward_liquid(
         return True
 
     return False
+
+
+def check_if_within_passive_start_window(
+    roll_data: RollDataWithStateReporting,
+    auto_parameters: autoRollParameters,
+) -> bool:
+    """Within the broader window where we start passive rolling (default 30 days).
+
+    The window is bounded ``0 <= days_until_roll < passive_start_days``. Negative
+    values (past the desired roll date) are not "early passive" — late-roll
+    escalation handles them separately.
+    """
+    return (
+        0 <= roll_data.days_until_roll
+        < auto_parameters.passive_start_days
+    )
 
 
 def check_if_getting_close_to_desired_roll_date(
@@ -658,6 +782,9 @@ def setup_roll_data_with_state_reporting(
 
     days_until_roll = diag_contracts.days_until_roll(instrument_code)
     days_until_expiry = diag_contracts.days_until_price_expiry(instrument_code)
+    any_key_contract_expired = check_if_any_key_contract_has_expired(
+        data=data, instrument_code=instrument_code
+    )
 
     relative_volume = relative_volume_in_forward_contract_versus_price(
         data=data, instrument_code=instrument_code
@@ -679,6 +806,7 @@ def setup_roll_data_with_state_reporting(
         relative_volume=relative_volume,
         absolute_forward_volume=absolute_forward_volume,
         days_until_expiry=days_until_expiry,
+        any_key_contract_expired=any_key_contract_expired,
     )
 
     return roll_data_with_state
@@ -690,6 +818,7 @@ def modify_roll_state(
     original_roll_state: RollState,
     roll_state_required: RollState,
     confirm_adjusted_price_change: bool = True,
+    allow_auto_forward_fill: bool = False,
 ):
     if roll_state_required == original_roll_state:
         return
@@ -709,6 +838,7 @@ def modify_roll_state(
             instrument_code=instrument_code,
             original_roll_state=original_roll_state,
             confirm_adjusted_price_change=confirm_adjusted_price_change,
+            allow_auto_forward_fill=allow_auto_forward_fill,
         )
 
     ## Following roll states require trading: force, forceoutright, close
@@ -738,6 +868,7 @@ def state_change_to_roll_adjusted_prices(
     instrument_code: str,
     original_roll_state: RollState,
     confirm_adjusted_price_change: bool = True,
+    allow_auto_forward_fill: bool = False,
 ):
     # Going to roll adjusted prices
     update_positions = updatePositions(data)
@@ -746,6 +877,7 @@ def state_change_to_roll_adjusted_prices(
         data=data,
         instrument_code=instrument_code,
         confirm_adjusted_price_change=confirm_adjusted_price_change,
+        allow_auto_forward_fill=allow_auto_forward_fill,
     )
 
     if roll_result is success:
@@ -765,7 +897,10 @@ def state_change_to_roll_adjusted_prices(
 
 
 def roll_adjusted_and_multiple_prices(
-    data: dataBlob, instrument_code: str, confirm_adjusted_price_change: bool = True
+    data: dataBlob,
+    instrument_code: str,
+    confirm_adjusted_price_change: bool = True,
+    allow_auto_forward_fill: bool = False,
 ) -> status:
     """
     Roll multiple and adjusted prices
@@ -774,6 +909,9 @@ def roll_adjusted_and_multiple_prices(
 
     :param data: dataBlob
     :param instrument_code: str
+    :param confirm_adjusted_price_change: if True, prompt user to confirm
+    :param allow_auto_forward_fill: if True, auto-try forward fill on error
+        instead of prompting (safe for non-interactive/cron use)
     :return:
     """
     print(landing_strip(80))
@@ -781,7 +919,9 @@ def roll_adjusted_and_multiple_prices(
     print("Rolling adjusted prices!")
     print("")
     rolling_adj_and_mult_object = get_roll_adjusted_multiple_prices_object(
-        data=data, instrument_code=instrument_code
+        data=data,
+        instrument_code=instrument_code,
+        allow_auto_forward_fill=allow_auto_forward_fill,
     )
     if rolling_adj_and_mult_object is failure:
         print("Error when trying to calculate roll prices")
@@ -818,6 +958,7 @@ def roll_adjusted_and_multiple_prices(
 def get_roll_adjusted_multiple_prices_object(
     data: dataBlob,
     instrument_code: str,
+    allow_auto_forward_fill: bool = False,
 ) -> rollingAdjustedAndMultiplePrices:
     ## returns failure if goes wrong
     try:
@@ -830,12 +971,43 @@ def get_roll_adjusted_multiple_prices_object(
 
     except Exception as e:
         print("Error %s when trying to calculate roll prices" % str(e))
-        ## Possibly forward fill
-        rolling_adj_and_mult_object = (
-            _get_roll_adjusted_multiple_prices_object_ffill_option(
-                data, instrument_code
+        if allow_auto_forward_fill:
+            ## Non-interactive mode: auto-try forward fill without prompting
+            rolling_adj_and_mult_object = (
+                _get_roll_adjusted_multiple_prices_object_auto_ffill(
+                    data, instrument_code
+                )
             )
+        else:
+            ## Interactive mode: ask user
+            rolling_adj_and_mult_object = (
+                _get_roll_adjusted_multiple_prices_object_ffill_option(
+                    data, instrument_code
+                )
+            )
+
+    return rolling_adj_and_mult_object
+
+
+def _get_roll_adjusted_multiple_prices_object_auto_ffill(
+    data: dataBlob, instrument_code: str
+) -> rollingAdjustedAndMultiplePrices:
+    """Non-interactive forward fill attempt — safe for cron/automated use."""
+    data.log.debug(
+        "Auto-attempting forward fill for %s roll price calculation" % instrument_code
+    )
+    try:
+        rolling_adj_and_mult_object = rollingAdjustedAndMultiplePrices(
+            data, instrument_code, allow_forward_fill=True
         )
+        _unused_ = rolling_adj_and_mult_object.updated_multiple_prices
+
+    except Exception as e:
+        data.log.warning(
+            "Error %s when trying to calculate roll prices for %s even with forward fill"
+            % (str(e), instrument_code)
+        )
+        return failure
 
     return rolling_adj_and_mult_object
 

--- a/sysproduction/linux/crontab
+++ b/sysproduction/linux/crontab
@@ -9,6 +9,9 @@
 05 07  * * 1-5     $HOME/.profile; $SCRIPT_PATH/run_daily_price_updates  >> $ECHO_PATH/run_daily_price_updates.txt 2>&1
 05 07  * * 1-5     $HOME/.profile; $SCRIPT_PATH/run_daily_fx_and_contract_updates  >> $ECHO_PATH/run_daily_fx_and_contract_updates.txt 2>&1
 00 23  * * 1-5     $HOME/.profile; $SCRIPT_PATH/run_daily_update_multiple_adjusted_prices  >> $ECHO_PATH/run_daily_update_multiple_adjusted_prices.txt 2>&1
+# Opt-in: non-interactive automated roll status. Uncomment to enable.
+# See docs/auto-roll-status.md for details.
+#30 23  * * 1-5     $HOME/.profile; $SCRIPT_PATH/run_auto_roll_status  >> $ECHO_PATH/run_auto_roll_status.txt 2>&1
 30 20  * * 1-5     $HOME/.profile; $SCRIPT_PATH/run_systems  >> $ECHO_PATH/run_systems.txt 2>&1
 45 20  * * 1-5     $HOME/.profile; $SCRIPT_PATH/run_strategy_order_generator  >> $ECHO_PATH/run_strategy_order_generator.txt 2>&1
 00 21  * * 1-5     $HOME/.profile; $SCRIPT_PATH/run_cleaners  >> $ECHO_PATH/run_cleaners.txt 2>&1

--- a/sysproduction/linux/scripts/run_auto_roll_status
+++ b/sysproduction/linux/scripts/run_auto_roll_status
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+. ~/.profile
+. p sysproduction.run_auto_roll_status.run_auto_roll_status

--- a/sysproduction/run_auto_roll_status.py
+++ b/sysproduction/run_auto_roll_status.py
@@ -1,0 +1,518 @@
+# Copyright 2026 Google LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Non-interactive automatic roll status update script.
+
+Runs daily after multiple/adjusted prices are updated and before the stack handler.
+Automatically updates roll status for instruments based on configured parameters.
+"""
+import datetime
+
+from syscontrol.run_process import processToRun
+from sysdata.data_blob import dataBlob
+from sysproduction.reporting.api import reportingApi
+from sysobjects.production.roll_state import RollState
+from sysproduction.interactive_update_roll_status import (
+    autoRollParameters,
+    get_list_of_instruments_to_auto_cycle,
+    setup_roll_data_with_state_reporting,
+    suggest_roll_state_for_instrument,
+    modify_roll_state,
+    get_auto_roll_parameters_potentially_using_default,
+    ASK_FOR_STATE,
+)
+from sysproduction.data.contracts import dataContracts
+from sysproduction.data.positions import diagPositions
+
+
+def run_auto_roll_status():
+    """Main entry point — integrates with processToRun for dashboard monitoring."""
+    process_name = "run_auto_roll_status"
+    with dataBlob(log_name=process_name) as data:
+        list_of_timer_names_and_functions = (
+            get_list_of_timer_functions_for_auto_roll_status()
+        )
+        auto_roll_process = processToRun(
+            process_name, data, list_of_timer_names_and_functions
+        )
+        auto_roll_process.run_process()
+
+
+def get_list_of_timer_functions_for_auto_roll_status():
+    with dataBlob(log_name="update_auto_roll_status") as data:
+        auto_roll_object = updateAutoRollStatus(data)
+        list_of_timer_names_and_functions = [
+            ("update_auto_roll_status", auto_roll_object),
+        ]
+        return list_of_timer_names_and_functions
+
+
+class updateAutoRollStatus(object):
+    """Callable timer function for the processToRun framework."""
+
+    def __init__(self, data: dataBlob):
+        self.data = data
+
+    def update_auto_roll_status(self):
+        data = self.data
+        api = reportingApi(data)
+        auto_roll_status_main(api=api, data=data)
+
+
+def auto_roll_status_main(api: reportingApi, data: dataBlob):
+    """
+    Automatically update roll status for all eligible instruments.
+
+    KEY FLOW:
+    1. Get auto parameters from config
+    2. days_ahead = max(passive_start_days, near_expiry_days) = max(30, 10) = 30
+    3. Get instrument list via get_list_of_instruments_to_auto_cycle()
+    4. Process each via process_instrument_roll_status()
+
+    NOTE: Instruments with a priced contract more than days_ahead days out
+    will be excluded from processing. This is by design — but means instruments
+    with orphaned positions in expired contracts (while priced contract is far out)
+    will also be missed by this pipeline.
+    """
+    auto_parameters = get_auto_roll_parameters_potentially_using_default(
+        data=data, use_default=True
+    )
+
+    days_ahead = max(auto_parameters.passive_start_days, auto_parameters.near_expiry_days)
+
+    instrument_list = get_list_of_instruments_to_auto_cycle(
+        data=api.data, days_ahead=days_ahead
+    )
+
+    if not instrument_list:
+        data.log.debug(
+            "No instruments within %d-day window requiring roll status check" % days_ahead
+        )
+        return
+
+    data.log.debug(
+        "Instruments within %d-day window for roll status check: %s"
+        % (days_ahead, instrument_list)
+    )
+
+    for instrument_code in instrument_list:
+        try:
+            process_instrument_roll_status(
+                data=data,
+                api=api,
+                instrument_code=instrument_code,
+                auto_parameters=auto_parameters,
+            )
+        except Exception as e:
+            data.log.critical(
+                "Error processing roll status for %s: %s" % (instrument_code, e)
+            )
+            continue
+
+
+def process_instrument_roll_status(
+    data: dataBlob,
+    api: reportingApi,
+    instrument_code: str,
+    auto_parameters: autoRollParameters,
+):
+    """
+    Process roll status for a single instrument.
+
+    EXPIRY ESCALATION LOGIC:
+    - Fires only if instrument is already in the selection list (passed days_ahead filter)
+    - Uses days_until_price_expiry (NOT days_until_roll, NOT min())
+    - Condition: days_until_expiry < near_expiry_days (10) AND position != 0
+
+    FORCE ROLL STUCK ESCALATION LOGIC:
+    - If instrument has been in Force state for more than force_roll_max_trading_days
+      without completing the roll, escalate to Force_Outright
+    - This handles cases where spread orders cannot execute due to missing tick data
+      or illiquid spread contracts (e.g., CRUDE_W_mini BAG contracts on IB)
+    """
+    roll_data = setup_roll_data_with_state_reporting(data, instrument_code)
+
+    _log_auto_roll_position_diagnostics(data, instrument_code, roll_data)
+
+    priced_contract_expiring_soon = roll_data.days_until_expiry < auto_parameters.near_expiry_days
+    position_held = roll_data.position_priced_contract != 0
+
+    # Check if Force roll is stuck and needs escalation to Force_Outright
+    if roll_data.original_roll_status == RollState.Force and position_held:
+        force_roll_stuck, trading_days = _is_force_roll_stuck(
+            data, instrument_code, auto_parameters
+        )
+        if force_roll_stuck:
+            roll_state_required = RollState.Force_Outright
+            data.log.critical(
+                "FORCE ROLL STUCK for %s: In Force state for %d trading days "
+                "(threshold: %d) without completing roll. "
+                "Escalating to Force_Outright to execute outright orders instead of spread."
+                % (
+                    instrument_code,
+                    trading_days,
+                    auto_parameters.force_roll_max_trading_days,
+                )
+            )
+            # Skip normal logic, go straight to state change
+            _apply_roll_state_change(
+                data, instrument_code, roll_data, roll_state_required
+            )
+            return
+
+    if priced_contract_expiring_soon and position_held:
+        roll_state_required = RollState.Force
+        reason = "expiry_escalation"
+        data.log.critical(
+            "EXPIRY ESCALATION for %s: "
+            "Priced contract has expired (days_until_expiry=%d) but position=%d is still held. "
+            "Overriding suggested state to Force."
+            % (
+                instrument_code,
+                roll_data.days_until_expiry,
+                roll_data.position_priced_contract,
+            )
+        )
+    else:
+        roll_state_required = suggest_roll_state_for_instrument(
+            roll_data=roll_data,
+            auto_parameters=auto_parameters,
+        )
+
+        # Determine reason for state selection
+        if roll_state_required == RollState.Force and roll_data.days_until_roll < 0 and roll_data.position_priced_contract != 0:
+            reason = "late_roll_escalation"
+        elif roll_state_required == RollState.Passive:
+            reason = "early_passive"
+        elif roll_state_required == RollState.No_Open:
+            reason = "forward_illiquid_close_to_roll"
+        elif roll_state_required == RollState.Roll_Adjusted:
+            if getattr(roll_data, "any_key_contract_expired", False):
+                reason = "expired_key_contract_auto_roll"
+            else:
+                reason = "roll_adjusted"
+        elif roll_state_required == RollState.No_Roll:
+            reason = "no_roll"
+        else:
+            reason = "default"
+
+        # If config says "Ask", auto-resolve to Force in non-interactive mode.
+        if roll_state_required == ASK_FOR_STATE:
+            roll_state_required = RollState.Force
+            reason = "auto_resolved_ask"
+            data.log.critical(
+                "AUTO-RESOLVED ASK_FOR_STATE to Force for %s: "
+                "Config default_roll_state_if_undecided is 'Ask' but running "
+                "non-interactively. Forward liquid, position=%d, "
+                "days_to_roll=%d, rel_vol=%.4f. "
+                "Consider changing config to 'Force' to silence this."
+                % (
+                    instrument_code,
+                    roll_data.position_priced_contract,
+                    roll_data.days_until_roll,
+                    roll_data.relative_volume,
+                )
+            )
+
+        if roll_state_required == RollState.Roll_Adjusted:
+            blocked, block_reason = _roll_adjusted_blocked_by_expiring_positions(
+                data=data,
+                instrument_code=instrument_code,
+                auto_parameters=auto_parameters,
+            )
+            if blocked:
+                data.log.critical(
+                    "ROLL_ADJUSTED BLOCKED for %s: %s. "
+                    "Leaving roll state unchanged and requiring manual/Force roll review."
+                    % (instrument_code, block_reason)
+                )
+                return
+
+    # No change needed
+    if roll_data.original_roll_status == roll_state_required:
+        data.log.debug(
+            "No roll status change needed for %s (current: %s)"
+            % (instrument_code, roll_data.original_roll_status.name)
+        )
+        return
+
+    allowable_states = roll_data.allowable_roll_states_as_list_of_str
+    if roll_state_required.name not in allowable_states:
+        data.log.critical(
+            "INVALID TRANSITION for %s: "
+            "Cannot change from %s to %s (position=%d). "
+            "Allowable transitions: %s. Skipping."
+            % (
+                instrument_code,
+                roll_data.original_roll_status.name,
+                roll_state_required.name,
+                roll_data.position_priced_contract,
+                allowable_states,
+            )
+        )
+        return
+
+    data.log.debug(
+        "Auto-updating roll state for %s: %s -> %s "
+        "reason=%s "
+        "(position=%d, days_until_expiry=%d, days_to_roll=%d, rel_vol=%.4f, fwd_vol=%d)"
+        % (
+            instrument_code,
+            roll_data.original_roll_status.name,
+            roll_state_required.name,
+            reason,
+            roll_data.position_priced_contract,
+            roll_data.days_until_expiry,
+            roll_data.days_until_roll,
+            roll_data.relative_volume,
+            roll_data.absolute_forward_volume,
+        )
+    )
+
+    modify_roll_state(
+        data=data,
+        instrument_code=instrument_code,
+        original_roll_state=roll_data.original_roll_status,
+        roll_state_required=roll_state_required,
+        confirm_adjusted_price_change=False,
+        allow_auto_forward_fill=True,
+    )
+
+
+def _log_auto_roll_position_diagnostics(
+    data: dataBlob,
+    instrument_code: str,
+    roll_data,
+):
+    """
+    Log the exact priced contract input and all current DB contract positions.
+
+    This makes the auto-roll decision auditable: if the priced-contract position
+    is zero but there are live positions in expiring/non-priced contracts, the
+    log will show that before any state change is made.
+    """
+    data_contracts = dataContracts(data)
+
+    priced_contract_id = data_contracts.get_priced_contract_id(instrument_code)
+    try:
+        priced_actual_expiry = data_contracts.get_actual_expiry(
+            instrument_code, priced_contract_id
+        ).as_str()
+    except Exception as exc:
+        priced_actual_expiry = "unknown (%s)" % str(exc)
+
+    current_positions = _current_contract_positions_for_instrument_as_strings(
+        data=data, instrument_code=instrument_code
+    )
+
+    data.log.debug(
+        "AUTO ROLL DIAGNOSTIC for %s: priced_contract=%s actual_expiry=%s "
+        "position_priced_contract=%d days_until_expiry=%d days_until_roll=%d "
+        "current_db_contract_positions=%s"
+        % (
+            instrument_code,
+            priced_contract_id,
+            priced_actual_expiry,
+            roll_data.position_priced_contract,
+            roll_data.days_until_expiry,
+            roll_data.days_until_roll,
+            current_positions,
+        )
+    )
+
+
+def _current_contract_positions_for_instrument_as_strings(
+    data: dataBlob, instrument_code: str
+) -> list:
+    diag_positions = diagPositions(data)
+    current_positions = diag_positions.get_all_current_contract_positions()
+
+    return [
+        str(position_entry)
+        for position_entry in current_positions
+        if position_entry.instrument_code == instrument_code
+    ]
+
+
+def _roll_adjusted_blocked_by_expiring_positions(
+    data: dataBlob,
+    instrument_code: str,
+    auto_parameters: autoRollParameters,
+) -> tuple:
+    """
+    Block no-position Roll_Adjusted if any DB contract position is expiring soon.
+
+    The normal decision is based on the current priced contract's position, so
+    a stale or orphaned non-priced DB leg can be missed once contract metadata
+    advances. Before changing to Roll_Adjusted, scan all current DB contract
+    positions for the instrument and refuse the adjusted-price roll if any live
+    position maps to an actual expiry inside the near-expiry window.
+    """
+    diag_positions = diagPositions(data)
+    data_contracts = dataContracts(data)
+    now = datetime.datetime.now()
+
+    blocking_positions = []
+    current_positions = diag_positions.get_all_current_contract_positions()
+    for position_entry in current_positions:
+        if position_entry.instrument_code != instrument_code:
+            continue
+        if position_entry.position == 0:
+            continue
+
+        contract = position_entry.contract
+        try:
+            actual_expiry = data_contracts.get_actual_expiry(
+                instrument_code, contract.date_str
+            )
+        except Exception as exc:
+            blocking_positions.append(
+                "%s position %d actual_expiry=unknown (%s)"
+                % (str(contract), position_entry.position, str(exc))
+            )
+            continue
+
+        days_until_actual_expiry = (actual_expiry - now).days
+        if days_until_actual_expiry < auto_parameters.near_expiry_days:
+            blocking_positions.append(
+                "%s position %d actual_expiry=%s days_until_expiry=%d"
+                % (
+                    str(contract),
+                    position_entry.position,
+                    actual_expiry.as_str(),
+                    days_until_actual_expiry,
+                )
+            )
+
+    if not blocking_positions:
+        return False, ""
+
+    return (
+        True,
+        "expiring DB contract positions exist despite zero priced-contract position: %s"
+        % blocking_positions,
+    )
+
+
+def _is_force_roll_stuck(
+    data: dataBlob,
+    instrument_code: str,
+    auto_parameters: autoRollParameters,
+) -> tuple:
+    """
+    Check if a Force roll has been stuck for more than the configured
+    number of trading days.
+
+    Returns:
+        tuple: (is_stuck: bool, trading_days: int)
+    """
+    from sysproduction.data.positions import diagPositions
+
+    diag_positions = diagPositions(data)
+    force_since = diag_positions.db_roll_state_data.get_roll_state_set_time(
+        instrument_code
+    )
+
+    if force_since is None:
+        # No timestamp recorded - state was set before this feature existed
+        # or state was changed manually. Can't determine stuck status.
+        return False, 0
+
+    trading_days = _count_trading_days_since(force_since)
+    max_days = getattr(auto_parameters, "force_roll_max_trading_days", 2)
+
+    return trading_days >= max_days, trading_days
+
+
+def _count_trading_days_since(start_date) -> int:
+    """
+    Count the number of trading days (weekdays) since the given date.
+    Uses a simple weekday count as a proxy for trading days.
+    """
+    import datetime
+
+    now = datetime.datetime.now()
+    # Convert to date if datetime
+    if hasattr(start_date, "date"):
+        start_date = start_date.date()
+    today = now.date()
+
+    trading_days = 0
+    current = start_date
+    while current < today:
+        # Monday = 0, Sunday = 6; count Mon-Fri as trading days
+        if current.weekday() < 5:
+            trading_days += 1
+        current += datetime.timedelta(days=1)
+
+    return trading_days
+
+
+def _apply_roll_state_change(
+    data: dataBlob,
+    instrument_code: str,
+    roll_data,
+    roll_state_required: RollState,
+    reason: str = "force_roll_stuck",
+):
+    """
+    Apply a roll state change, checking allowable transitions.
+    Used by the force roll stuck escalation logic.
+    """
+    allowable_states = roll_data.allowable_roll_states_as_list_of_str
+    if roll_state_required.name not in allowable_states:
+        data.log.critical(
+            "INVALID TRANSITION for %s: "
+            "Cannot change from %s to %s (position=%d). "
+            "Allowable transitions: %s. Skipping."
+            % (
+                instrument_code,
+                roll_data.original_roll_status.name,
+                roll_state_required.name,
+                roll_data.position_priced_contract,
+                allowable_states,
+            )
+        )
+        return
+
+    data.log.debug(
+        "Auto-updating roll state for %s: %s -> %s "
+        "reason=%s "
+        "(position=%d, days_until_expiry=%d, days_to_roll=%d, rel_vol=%.4f, fwd_vol=%d)"
+        % (
+            instrument_code,
+            roll_data.original_roll_status.name,
+            roll_state_required.name,
+            reason,
+            roll_data.position_priced_contract,
+            roll_data.days_until_expiry,
+            roll_data.days_until_roll,
+            roll_data.relative_volume,
+            roll_data.absolute_forward_volume,
+        )
+    )
+
+    modify_roll_state(
+        data=data,
+        instrument_code=instrument_code,
+        original_roll_state=roll_data.original_roll_status,
+        roll_state_required=roll_state_required,
+        confirm_adjusted_price_change=False,
+        allow_auto_forward_fill=True,
+    )
+
+
+if __name__ == "__main__":
+    run_auto_roll_status()

--- a/tests/test_auto_roll_status.py
+++ b/tests/test_auto_roll_status.py
@@ -1,0 +1,1087 @@
+# Copyright 2026 Google LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Comprehensive tests for the automatic roll status system.
+
+Tests cover:
+  1. suggest_roll_state_for_instrument — all decision branches
+  2. Volume threshold logic (liquid vs illiquid forward)
+  3. Time boundary logic (near_expiry_days, passive_start_days)
+  4. Early passive rolling
+  5. ASK_FOR_STATE auto-resolution
+  6. State transition validation against the allowable transition matrix
+  7. process_instrument_roll_status integration logic
+  8. Expiry escalation: Passive+position+expiring_soon → Force
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from sysobjects.production.roll_state import (
+    RollState,
+    allowable_roll_state_from_current_and_position,
+)
+from sysproduction.interactive_update_roll_status import (
+    suggest_roll_state_for_instrument,
+    check_if_forward_liquid,
+    check_if_within_passive_start_window,
+    check_if_getting_close_to_desired_roll_date,
+    include_instrument_in_auto_cycle,
+    check_if_any_key_contract_has_expired,
+    autoRollParameters,
+    RollDataWithStateReporting,
+    ASK_FOR_STATE,
+)
+
+
+# ============================================================================
+# Fixtures: default parameters and roll data builders
+# ============================================================================
+
+def make_auto_params(
+    auto_roll_if_relative_volume_higher_than=1.0,
+    min_relative_volume=0.01,
+    min_absolute_volume=100,
+    near_expiry_days=10,
+    default_roll_state_if_undecided=RollState.Force,
+    auto_roll_expired=True,
+    passive_start_days=30,
+    force_roll_max_trading_days=2,
+):
+    return autoRollParameters(
+        auto_roll_if_relative_volume_higher_than=auto_roll_if_relative_volume_higher_than,
+        min_relative_volume=min_relative_volume,
+        min_absolute_volume=min_absolute_volume,
+        near_expiry_days=near_expiry_days,
+        default_roll_state_if_undecided=default_roll_state_if_undecided,
+        auto_roll_expired=auto_roll_expired,
+        passive_start_days=passive_start_days,
+        force_roll_max_trading_days=force_roll_max_trading_days,
+    )
+
+
+def make_roll_data(
+    instrument_code="TEST",
+    original_roll_status=RollState.No_Roll,
+    position_priced_contract=0,
+    days_until_roll=50,
+    relative_volume=0.0,
+    absolute_forward_volume=0,
+    days_until_expiry=60,
+):
+    allowable = allowable_roll_state_from_current_and_position(
+        original_roll_status, position_priced_contract
+    )
+    return RollDataWithStateReporting(
+        instrument_code=instrument_code,
+        original_roll_status=original_roll_status,
+        position_priced_contract=position_priced_contract,
+        allowable_roll_states_as_list_of_str=allowable,
+        days_until_roll=days_until_roll,
+        relative_volume=relative_volume,
+        absolute_forward_volume=absolute_forward_volume,
+        days_until_expiry=days_until_expiry,
+    )
+
+
+DEFAULT_PARAMS = make_auto_params()
+
+
+# ============================================================================
+# 1. CORE DECISION LOGIC: suggest_roll_state_for_instrument
+# ============================================================================
+
+class TestSuggestRollStateExpired:
+    """Expired priced contract scenarios.
+
+    NOTE: suggest_roll_state_for_instrument only handles expired+NO_POSITION
+    via check_if_expired_and_auto_rolling_expired. The expired+POSITION case
+    is handled upstream in process_instrument_roll_status (expiry escalation).
+    These tests verify what suggest returns in each case so the escalation
+    logic knows what it's overriding.
+    """
+
+    def test_expired_no_position_auto_roll(self):
+        """Expired + no position + auto_roll_expired=True → Roll_Adjusted."""
+        roll_data = make_roll_data(
+            position_priced_contract=0,
+            days_until_expiry=-1,
+            days_until_roll=50,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Roll_Adjusted
+
+    def test_expired_no_position_auto_roll_disabled(self):
+        """Expired + no position + auto_roll_expired=False → falls through to normal logic."""
+        params = make_auto_params(auto_roll_expired=False)
+        roll_data = make_roll_data(
+            position_priced_contract=0,
+            days_until_expiry=-1,
+            days_until_roll=50,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+        )
+        # Forward illiquid, far from roll → No_Roll
+        result = suggest_roll_state_for_instrument(roll_data, params)
+        assert result == RollState.No_Roll
+
+    def test_expired_with_position_suggest_returns_no_roll(self):
+        """Expired + position held → suggest returns No_Roll (the gap).
+
+        This documents the known gap: suggest_roll_state_for_instrument does NOT
+        escalate to Force when expired+position. The escalation is handled by
+        process_instrument_roll_status (see TestExpiryEscalation).
+        """
+        roll_data = make_roll_data(
+            position_priced_contract=10,
+            days_until_expiry=-1,
+            days_until_roll=50,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        # Has position, forward illiquid, far from roll → No_Roll. The
+        # higher-level expiry escalation in process_instrument_roll_status is
+        # what catches this case; suggest itself does not.
+        assert result == RollState.No_Roll
+
+    def test_expired_exactly_at_zero(self):
+        """Expired at exactly day 0 → Roll_Adjusted for no position."""
+        roll_data = make_roll_data(
+            position_priced_contract=0,
+            days_until_expiry=0,
+            days_until_roll=50,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Roll_Adjusted
+
+    def test_expired_key_contract_no_position_auto_roll(self):
+        """Expired carry/key contract + no position → Roll_Adjusted even if priced expiry is far out.
+
+        Regression for BUTTER/CHEESE/MILKWET: the carry contract can expire while
+        the priced contract remains outside the normal auto-roll look-ahead window.
+        """
+        roll_data = make_roll_data(
+            instrument_code="BUTTER",
+            position_priced_contract=0,
+            days_until_expiry=33,  # priced contract still outside 30-day window
+            days_until_roll=-7,
+            relative_volume=0.05,
+            absolute_forward_volume=27,
+        )
+        roll_data.any_key_contract_expired = True
+
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Roll_Adjusted
+
+    def test_expired_key_contract_no_position_respects_auto_roll_disabled(self):
+        """Expired key contract does not force Roll_Adjusted if auto_roll_expired=False."""
+        params = make_auto_params(auto_roll_expired=False)
+        roll_data = make_roll_data(
+            instrument_code="BUTTER",
+            position_priced_contract=0,
+            days_until_expiry=33,
+            days_until_roll=-7,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+        )
+        roll_data.any_key_contract_expired = True
+
+        result = suggest_roll_state_for_instrument(roll_data, params)
+        assert result == RollState.No_Open
+
+    def test_expired_key_contract_with_position_still_uses_late_escalation(self):
+        """Expired key contract + position should not Roll_Adjusted over a live position."""
+        roll_data = make_roll_data(
+            instrument_code="BUTTER",
+            original_roll_status=RollState.No_Roll,
+            position_priced_contract=1,
+            days_until_expiry=33,
+            days_until_roll=-7,
+            relative_volume=0.05,
+            absolute_forward_volume=27,
+        )
+        roll_data.any_key_contract_expired = True
+
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Force
+
+
+class TestSuggestRollStateForwardLiquid:
+    """Forward contract is liquid scenarios."""
+
+    def test_liquid_no_position(self):
+        """Forward liquid + no position → Roll_Adjusted."""
+        roll_data = make_roll_data(
+            position_priced_contract=0,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_roll=50,
+            days_until_expiry=60,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Roll_Adjusted
+
+    def test_liquid_with_position_far_from_roll(self):
+        """Forward liquid + position + far from roll → Passive."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_roll=50,
+            days_until_expiry=60,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Passive
+
+    def test_liquid_with_position_close_to_roll_force(self):
+        """Forward liquid + position + close to roll + default=Force → Force."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_roll=5,
+            days_until_expiry=15,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Force
+
+    def test_liquid_with_position_close_to_roll_force_outright(self):
+        """Forward liquid + position + close to roll + default=Force_Outright."""
+        params = make_auto_params(default_roll_state_if_undecided=RollState.Force_Outright)
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_roll=5,
+            days_until_expiry=15,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, params)
+        assert result == RollState.Force_Outright
+
+    def test_liquid_with_position_close_to_roll_close(self):
+        """Forward liquid + position + close to roll + default=Close."""
+        params = make_auto_params(default_roll_state_if_undecided=RollState.Close)
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_roll=5,
+            days_until_expiry=15,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, params)
+        assert result == RollState.Close
+
+    def test_liquid_with_position_close_to_roll_ask(self):
+        """Forward liquid + position + close to roll + default=Ask → 'Ask' string."""
+        params = make_auto_params(default_roll_state_if_undecided=ASK_FOR_STATE)
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_roll=5,
+            days_until_expiry=15,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, params)
+        assert result == ASK_FOR_STATE
+        assert result == "Ask"
+
+    def test_liquid_at_exactly_near_expiry_boundary(self):
+        """days_until_roll == 9 (< near_expiry_days=10) → close → Force."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_roll=9,
+            days_until_expiry=20,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Force
+
+    def test_liquid_at_exactly_near_expiry_boundary_not_close(self):
+        """days_until_roll == 10 (== near_expiry_days, NOT < 10) → not close → Passive."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_roll=10,
+            days_until_expiry=20,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Passive
+
+
+class TestSuggestRollStateForwardIlliquid:
+    """Forward contract is illiquid scenarios."""
+
+    def test_illiquid_far_from_roll_no_position(self):
+        """Forward illiquid + no position + far from roll → No_Roll."""
+        roll_data = make_roll_data(
+            position_priced_contract=0,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_roll=50,
+            days_until_expiry=60,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Roll
+
+    def test_illiquid_close_to_roll_no_position(self):
+        """Forward illiquid + no position + close to roll → No_Open."""
+        roll_data = make_roll_data(
+            position_priced_contract=0,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_roll=5,
+            days_until_expiry=15,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Open
+
+    def test_illiquid_close_to_roll_with_position(self):
+        """Forward illiquid + position + close to roll + zero volume → No_Open."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_roll=5,
+            days_until_expiry=15,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Open
+
+    def test_illiquid_far_from_roll_with_position(self):
+        """Forward illiquid + position + far from everything → No_Roll."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_roll=50,
+            days_until_expiry=60,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Roll
+
+
+# ============================================================================
+# 2. EARLY PASSIVE ROLLING
+# ============================================================================
+
+class TestEarlyPassiveRolling:
+    """Forward illiquid but has *some* volume within passive_start_days window."""
+
+    def test_early_passive_within_window_some_volume(self):
+        """Illiquid forward + position + within 30 days + some volume → Passive."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+            days_until_roll=20,
+            days_until_expiry=30,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Passive
+
+    def test_early_passive_within_window_zero_volume(self):
+        """Illiquid forward + position + within 30 days + zero volume → NOT Passive."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_roll=20,
+            days_until_expiry=30,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Roll
+
+    def test_early_passive_outside_window_some_volume(self):
+        """Illiquid forward + position + OUTSIDE 30 days + some volume → No_Roll."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+            days_until_roll=35,
+            days_until_expiry=45,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Roll
+
+    def test_early_passive_no_position_within_window(self):
+        """Illiquid forward + NO position + within 30 days + some volume → No_Roll (not Passive)."""
+        roll_data = make_roll_data(
+            position_priced_contract=0,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+            days_until_roll=20,
+            days_until_expiry=30,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Roll
+
+    def test_early_passive_at_boundary(self):
+        """Illiquid forward + position + at exactly passive_start_days boundary → NOT Passive."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+            days_until_roll=30,  # == passive_start_days, NOT < 30
+            days_until_expiry=40,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Roll
+
+    def test_early_passive_just_inside_boundary(self):
+        """Illiquid forward + position + at 29 days (just inside) → Passive."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+            days_until_roll=29,
+            days_until_expiry=39,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Passive
+
+    def test_early_passive_relative_vol_zero_but_absolute_nonzero(self):
+        """relative_volume=0 but absolute_forward_volume>0 → NOT Passive (both must be >0)."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.0,
+            absolute_forward_volume=20,
+            days_until_roll=20,
+            days_until_expiry=30,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Roll
+
+    def test_early_passive_relative_vol_nonzero_but_absolute_zero(self):
+        """relative_volume>0 but absolute_forward_volume=0 → NOT Passive."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.005,
+            absolute_forward_volume=0,
+            days_until_roll=20,
+            days_until_expiry=30,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.No_Roll
+
+    def test_early_passive_close_to_roll_with_some_volume(self):
+        """Within passive window AND near_expiry_days + some volume → Passive wins over No_Open."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+            days_until_roll=5,  # within both passive_start_days AND near_expiry_days
+            days_until_expiry=15,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        # Early passive check comes BEFORE the near_expiry check in the illiquid branch
+        assert result == RollState.Passive
+
+
+# ============================================================================
+# 3. VOLUME THRESHOLD LOGIC: check_if_forward_liquid
+# ============================================================================
+
+class TestCheckIfForwardLiquid:
+    """Volume-based liquidity determination."""
+
+    def test_very_high_relative_volume(self):
+        """relative > auto_roll_if_relative_volume_higher_than → liquid."""
+        roll_data = make_roll_data(relative_volume=1.5)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is True
+
+    def test_exactly_at_auto_roll_threshold(self):
+        """relative == threshold → NOT liquid (must be > not >=)."""
+        roll_data = make_roll_data(relative_volume=1.0)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is False
+
+    def test_relative_and_absolute_both_met(self):
+        """relative > min_relative AND absolute > min_absolute → liquid."""
+        roll_data = make_roll_data(relative_volume=0.05, absolute_forward_volume=200)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is True
+
+    def test_relative_met_absolute_not(self):
+        """relative > min but absolute below threshold → NOT liquid."""
+        roll_data = make_roll_data(relative_volume=0.05, absolute_forward_volume=50)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is False
+
+    def test_absolute_met_relative_not(self):
+        """absolute > min but relative below threshold → NOT liquid."""
+        roll_data = make_roll_data(relative_volume=0.005, absolute_forward_volume=200)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is False
+
+    def test_both_below_threshold(self):
+        """Both below → NOT liquid."""
+        roll_data = make_roll_data(relative_volume=0.005, absolute_forward_volume=50)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is False
+
+    def test_zero_volume(self):
+        """Zero everything → NOT liquid."""
+        roll_data = make_roll_data(relative_volume=0.0, absolute_forward_volume=0)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is False
+
+    def test_at_min_relative_boundary(self):
+        """relative == min_relative_volume (0.01) → NOT liquid (must be >)."""
+        roll_data = make_roll_data(relative_volume=0.01, absolute_forward_volume=200)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is False
+
+    def test_at_min_absolute_boundary(self):
+        """absolute == min_absolute_volume (100) → NOT liquid (must be >)."""
+        roll_data = make_roll_data(relative_volume=0.05, absolute_forward_volume=100)
+        assert check_if_forward_liquid(roll_data, DEFAULT_PARAMS) is False
+
+
+# ============================================================================
+# 4. TIME BOUNDARY LOGIC
+# ============================================================================
+
+class TestTimeBoundaries:
+    """Near-expiry and passive start window checks."""
+
+    def test_close_to_roll(self):
+        roll_data = make_roll_data(days_until_roll=5)
+        assert check_if_getting_close_to_desired_roll_date(roll_data, DEFAULT_PARAMS) is True
+
+    def test_not_close_to_roll(self):
+        roll_data = make_roll_data(days_until_roll=15)
+        assert check_if_getting_close_to_desired_roll_date(roll_data, DEFAULT_PARAMS) is False
+
+    def test_exactly_at_near_expiry_days(self):
+        """days_until_roll == 10 → NOT close (strict <)."""
+        roll_data = make_roll_data(days_until_roll=10)
+        assert check_if_getting_close_to_desired_roll_date(roll_data, DEFAULT_PARAMS) is False
+
+    def test_one_day_before_near_expiry(self):
+        roll_data = make_roll_data(days_until_roll=9)
+        assert check_if_getting_close_to_desired_roll_date(roll_data, DEFAULT_PARAMS) is True
+
+    def test_within_passive_window(self):
+        roll_data = make_roll_data(days_until_roll=20)
+        assert check_if_within_passive_start_window(roll_data, DEFAULT_PARAMS) is True
+
+    def test_outside_passive_window(self):
+        roll_data = make_roll_data(days_until_roll=35)
+        assert check_if_within_passive_start_window(roll_data, DEFAULT_PARAMS) is False
+
+    def test_at_passive_window_boundary(self):
+        """days_until_roll == 30 → NOT within (strict <)."""
+        roll_data = make_roll_data(days_until_roll=30)
+        assert check_if_within_passive_start_window(roll_data, DEFAULT_PARAMS) is False
+
+    def test_just_inside_passive_window(self):
+        roll_data = make_roll_data(days_until_roll=29)
+        assert check_if_within_passive_start_window(roll_data, DEFAULT_PARAMS) is True
+
+
+class TestAutoCycleSelectionExpiredKeyContracts:
+    """Selection tests for expired carry/key contracts.
+
+    Regression for BUTTER/CHEESE/MILKWET: daily_fx_and_contract_updates checks
+    every key contract, but auto-roll previously selected only by priced-contract
+    expiry. These tests ensure an expired carry contract brings the instrument
+    into the auto-roll cycle even when the priced contract is still outside the
+    normal look-ahead window.
+    """
+
+    @patch("sysproduction.interactive_update_roll_status.dataContracts")
+    def test_include_when_priced_expiry_outside_window_but_key_contract_expired(
+        self, mock_data_contracts_class
+    ):
+        mock_data_contracts = mock_data_contracts_class.return_value
+        mock_data_contracts.days_until_price_expiry.return_value = 33
+        mock_data_contracts.get_labelled_dict_of_current_contracts.return_value = {
+            "contracts": ["20260400", "20260500", "20260600"],
+            "labels": ["20260400c", "20260500p", "20260600f"],
+        }
+
+        expired_contract = MagicMock()
+        expired_contract.expired.return_value = True
+        active_contract = MagicMock()
+        active_contract.expired.return_value = False
+        mock_data_contracts.get_contract_from_db.side_effect = [
+            expired_contract,
+            active_contract,
+            active_contract,
+        ]
+
+        assert include_instrument_in_auto_cycle(
+            data=MagicMock(), instrument_code="BUTTER", days_ahead=30
+        ) is True
+
+    @patch("sysproduction.interactive_update_roll_status.dataContracts")
+    def test_do_not_include_when_priced_expiry_outside_window_and_no_key_expired(
+        self, mock_data_contracts_class
+    ):
+        mock_data_contracts = mock_data_contracts_class.return_value
+        mock_data_contracts.days_until_price_expiry.return_value = 33
+        mock_data_contracts.get_labelled_dict_of_current_contracts.return_value = {
+            "contracts": ["20260500", "20260600", "20260700"],
+            "labels": ["20260500c", "20260600p", "20260700f"],
+        }
+
+        active_contract = MagicMock()
+        active_contract.expired.return_value = False
+        mock_data_contracts.get_contract_from_db.return_value = active_contract
+
+        assert include_instrument_in_auto_cycle(
+            data=MagicMock(), instrument_code="TEST", days_ahead=30
+        ) is False
+
+    @patch("sysproduction.interactive_update_roll_status.dataContracts")
+    def test_key_contract_helper_detects_expired_contract(
+        self, mock_data_contracts_class
+    ):
+        mock_data_contracts = mock_data_contracts_class.return_value
+        mock_data_contracts.get_labelled_dict_of_current_contracts.return_value = {
+            "contracts": ["20260400", "20260500"],
+            "labels": ["20260400c", "20260500p"],
+        }
+        expired_contract = MagicMock()
+        expired_contract.expired.return_value = True
+        active_contract = MagicMock()
+        active_contract.expired.return_value = False
+        mock_data_contracts.get_contract_from_db.side_effect = [
+            active_contract,
+            expired_contract,
+        ]
+
+        assert check_if_any_key_contract_has_expired(
+            data=MagicMock(), instrument_code="CHEESE"
+        ) is True
+
+    @patch("sysproduction.interactive_update_roll_status.dataContracts")
+    def test_missing_forward_contract_is_tolerated(self, mock_data_contracts_class):
+        # Regression: immediately after a Roll_Adjusted the forward slot of the
+        # multiple-prices chain points to a contract that update_sampled_contracts
+        # has not yet written to the contracts DB. The helper must treat that as
+        # not-expired rather than crashing on ContractNotFound.
+        from syscore.exceptions import ContractNotFound
+
+        mock_data_contracts = mock_data_contracts_class.return_value
+        mock_data_contracts.get_labelled_dict_of_current_contracts.return_value = {
+            "contracts": ["20260600", "20260700", "20260900"],
+            "labels": ["20260600c", "20260700p", "20260900f"],
+        }
+        active_contract = MagicMock()
+        active_contract.expired.return_value = False
+        mock_data_contracts.get_contract_from_db.side_effect = [
+            active_contract,
+            active_contract,
+            ContractNotFound("missing"),
+        ]
+
+        assert check_if_any_key_contract_has_expired(
+            data=MagicMock(), instrument_code="NIKKEI"
+        ) is False
+
+    @patch("sysproduction.interactive_update_roll_status.dataContracts")
+    def test_missing_priced_or_carry_contract_alerts_and_skips(
+        self, mock_data_contracts_class
+    ):
+        # A missing carry or priced contract is never expected — it implies the
+        # multiple-prices chain references a delisted or mistyped contract.
+        # The helper must emit a critical log and skip that leg without crashing.
+        from syscore.exceptions import ContractNotFound
+
+        mock_data_contracts = mock_data_contracts_class.return_value
+        mock_data_contracts.get_labelled_dict_of_current_contracts.return_value = {
+            "contracts": ["20260600", "20260700", "20260900"],
+            "labels": ["20260600c", "20260700p", "20260900f"],
+        }
+        active_contract = MagicMock()
+        active_contract.expired.return_value = False
+        mock_data_contracts.get_contract_from_db.side_effect = [
+            ContractNotFound("missing carry"),
+            active_contract,
+            active_contract,
+        ]
+
+        mock_data = MagicMock()
+        assert check_if_any_key_contract_has_expired(
+            data=mock_data, instrument_code="WIDGET"
+        ) is False
+        mock_data.log.critical.assert_called_once()
+
+
+# ============================================================================
+# 5. EXPIRY ESCALATION
+# ============================================================================
+
+class TestExpiryEscalation:
+    """
+    process_instrument_roll_status escalates to Force when the priced contract
+    is expiring within near_expiry_days and a position is still held.
+
+    This closes the gap where suggest_roll_state_for_instrument would return
+    No_Roll (or the current state) for expired+position, leaving the instrument
+    in Passive until the stack handler detected a break and locked it.
+
+    The condition is: days_until_expiry < near_expiry_days AND position != 0
+    Using near_expiry_days (default 10) rather than <= 0 gives the stack handler
+    time to execute the Force roll before the contract disappears.
+    """
+
+
+# ============================================================================
+# 13. EXPIRY ESCALATION IN process_instrument_roll_status
+# ============================================================================
+
+class TestLateRollEscalation:
+    """Late-roll behaviour: when the desired roll date has passed and a
+    position is still held, the system must never downgrade urgency.
+
+    Scenarios cover Force/Force_Outright/Close holding their state, and lower-
+    urgency states (No_Roll, Passive) escalating to Force.
+    """
+
+    def test_gas_us_mini_force_not_downgraded_to_passive(self):
+        """GAS_US_mini: Force + position + days_until_roll=-8 should NOT become Passive."""
+        roll_data = make_roll_data(
+            instrument_code="GAS_US_mini",
+            original_roll_status=RollState.Force,
+            position_priced_contract=-1,
+            days_until_roll=-8,
+            relative_volume=0.0828,
+            absolute_forward_volume=94,
+            days_until_expiry=27,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        # Should stay in Force, NOT downgrade to Passive
+        assert result == RollState.Force
+
+    def test_gas_us_mini_no_roll_escalates_to_force(self):
+        """GAS_US_mini: No_Roll + position + days_until_roll=-8 should escalate to Force."""
+        roll_data = make_roll_data(
+            instrument_code="GAS_US_mini",
+            original_roll_status=RollState.No_Roll,
+            position_priced_contract=-1,
+            days_until_roll=-8,
+            relative_volume=0.0828,
+            absolute_forward_volume=94,
+            days_until_expiry=27,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        # Should escalate to Force
+        assert result == RollState.Force
+
+    def test_gas_us_mini_passive_not_downgraded_when_past_roll_date(self):
+        """GAS_US_mini: Passive + position + days_until_roll=-8 should escalate to Force."""
+        roll_data = make_roll_data(
+            instrument_code="GAS_US_mini",
+            original_roll_status=RollState.Passive,
+            position_priced_contract=-1,
+            days_until_roll=-8,
+            relative_volume=0.0828,
+            absolute_forward_volume=94,
+            days_until_expiry=27,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        # Should escalate to Force, not stay Passive
+        assert result == RollState.Force
+
+    def test_force_outright_kept_when_past_roll_date(self):
+        """Force_Outright + position + days_until_roll=-8 should stay Force_Outright."""
+        roll_data = make_roll_data(
+            instrument_code="TEST",
+            original_roll_status=RollState.Force_Outright,
+            position_priced_contract=5,
+            days_until_roll=-5,
+            relative_volume=0.1,
+            absolute_forward_volume=50,
+            days_until_expiry=20,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Force_Outright
+
+    def test_close_kept_when_past_roll_date(self):
+        """Close + position + days_until_roll=-5 should stay Close."""
+        roll_data = make_roll_data(
+            instrument_code="TEST",
+            original_roll_status=RollState.Close,
+            position_priced_contract=5,
+            days_until_roll=-5,
+            relative_volume=0.1,
+            absolute_forward_volume=50,
+            days_until_expiry=20,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Close
+
+
+class TestGasPenNoPositionNoOpen:
+    """No-position + past-roll-date + illiquid forward should remain No_Open.
+
+    With no position there is nothing to escalate; the right action is to keep
+    the instrument flagged for no opens until the forward becomes liquid.
+    """
+
+    def test_gas_pen_no_position_past_roll_date_no_open(self):
+        """GAS-PEN: No_Roll + no position + days_until_roll=-8 + no volume -> No_Open."""
+        roll_data = make_roll_data(
+            instrument_code="GAS-PEN",
+            original_roll_status=RollState.No_Roll,
+            position_priced_contract=0,
+            days_until_roll=-8,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_expiry=27,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        # Should be No_Open (forward illiquid, close to roll date)
+        assert result == RollState.No_Open
+
+    def test_gas_pen_no_position_no_escalation_to_force(self):
+        """GAS-PEN: No position should NOT escalate to Force even past roll date."""
+        roll_data = make_roll_data(
+            instrument_code="GAS-PEN",
+            original_roll_status=RollState.No_Roll,
+            position_priced_contract=0,
+            days_until_roll=-8,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_expiry=27,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        # Should NOT be Force - no position means no trading emergency
+        assert result != RollState.Force
+
+
+class TestBoundedPassiveWindow:
+    """The passive window is bounded: 0 <= days_until_roll < passive_start_days.
+
+    Negative values (past the desired roll date) must not count as "early
+    passive" — they are handled by late-roll escalation instead.
+    """
+
+    def test_negative_days_not_in_passive_window(self):
+        """days_until_roll=-8 should NOT be within passive window."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            days_until_roll=-8,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+        )
+        from sysproduction.interactive_update_roll_status import (
+            check_if_within_passive_start_window,
+        )
+        result = check_if_within_passive_start_window(roll_data, DEFAULT_PARAMS)
+        assert result is False
+
+    def test_zero_days_in_passive_window(self):
+        """days_until_roll=0 should be within passive window."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            days_until_roll=0,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+        )
+        from sysproduction.interactive_update_roll_status import (
+            check_if_within_passive_start_window,
+        )
+        result = check_if_within_passive_start_window(roll_data, DEFAULT_PARAMS)
+        assert result is True
+
+    def test_early_passive_still_works_for_positive_days(self):
+        """days_until_roll=20 should still trigger early passive."""
+        roll_data = make_roll_data(
+            position_priced_contract=5,
+            days_until_roll=20,
+            relative_volume=0.005,
+            absolute_forward_volume=20,
+            days_until_expiry=30,
+        )
+        result = suggest_roll_state_for_instrument(roll_data, DEFAULT_PARAMS)
+        assert result == RollState.Passive
+
+
+class TestExpiryEscalationInProcess:
+    """Test the expiry escalation logic in process_instrument_roll_status.
+    
+    The current implementation uses days_until_expiry from roll_data directly
+    to determine if escalation to Force is needed.
+    """
+
+    @patch("sysproduction.run_auto_roll_status.setup_roll_data_with_state_reporting")
+    @patch("sysproduction.run_auto_roll_status.suggest_roll_state_for_instrument")
+    @patch("sysproduction.run_auto_roll_status.modify_roll_state")
+    def test_expiry_escalation_to_force(
+        self, mock_modify, mock_suggest, mock_setup
+    ):
+        """When priced contract is expiring soon with position, escalate to Force."""
+        from sysproduction.run_auto_roll_status import process_instrument_roll_status
+        from sysproduction.interactive_update_roll_status import RollDataWithStateReporting
+        
+        # Setup roll_data with expiring contract and position
+        # Allowable states must include Force for position > 0
+        roll_data = RollDataWithStateReporting(
+            instrument_code="VIX",
+            original_roll_status=RollState.Passive,
+            position_priced_contract=5,  # Has position
+            allowable_roll_states_as_list_of_str=['Roll_Adjusted', 'Passive', 'No_Roll', 'No_Open', 'Force', 'Force_Outright', 'Close'],
+            days_until_roll=5,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_expiry=3,  # Expiring soon (< near_expiry_days=10)
+        )
+        mock_setup.return_value = roll_data
+        
+        data = MagicMock()
+        auto_params = DEFAULT_PARAMS
+        
+        process_instrument_roll_status(
+            data=data, api=MagicMock(), instrument_code="VIX",
+            auto_parameters=auto_params,
+        )
+        
+        # Should escalate to Force and call modify_roll_state
+        mock_modify.assert_called_once()
+        assert mock_modify.call_args[1]["roll_state_required"] == RollState.Force
+        
+        # Should log EXPIRY ESCALATION
+        escalation_logs = [
+            c for c in data.log.critical.call_args_list
+            if "EXPIRY ESCALATION" in str(c)
+        ]
+        assert len(escalation_logs) == 1
+
+    @patch("sysproduction.run_auto_roll_status.setup_roll_data_with_state_reporting")
+    @patch("sysproduction.run_auto_roll_status.suggest_roll_state_for_instrument")
+    @patch("sysproduction.run_auto_roll_status.modify_roll_state")
+    def test_no_escalation_when_no_position(
+        self, mock_modify, mock_suggest, mock_setup
+    ):
+        """No escalation when contract is expiring but no position held."""
+        from sysproduction.run_auto_roll_status import process_instrument_roll_status
+        from sysproduction.interactive_update_roll_status import RollDataWithStateReporting
+        
+        roll_data = RollDataWithStateReporting(
+            instrument_code="VIX",
+            original_roll_status=RollState.Passive,
+            position_priced_contract=0,  # No position
+            allowable_roll_states_as_list_of_str=['Roll_Adjusted', 'Passive', 'No_Roll', 'No_Open'],
+            days_until_roll=5,
+            relative_volume=0.0,
+            absolute_forward_volume=0,
+            days_until_expiry=3,  # Expiring soon but no position
+        )
+        mock_setup.return_value = roll_data
+        mock_suggest.return_value = RollState.Roll_Adjusted
+        
+        data = MagicMock()
+        auto_params = DEFAULT_PARAMS
+        
+        process_instrument_roll_status(
+            data=data, api=MagicMock(), instrument_code="VIX",
+            auto_parameters=auto_params,
+        )
+        
+        # Should NOT escalate - should use suggest result
+        assert mock_suggest.called
+        # Should NOT log EXPIRY ESCALATION
+        escalation_logs = [
+            c for c in data.log.critical.call_args_list
+            if "EXPIRY ESCALATION" in str(c)
+        ]
+        assert len(escalation_logs) == 0
+
+    @patch("sysproduction.run_auto_roll_status.setup_roll_data_with_state_reporting")
+    @patch("sysproduction.run_auto_roll_status.suggest_roll_state_for_instrument")
+    @patch("sysproduction.run_auto_roll_status.modify_roll_state")
+    def test_no_escalation_when_not_expiring_soon(
+        self, mock_modify, mock_suggest, mock_setup
+    ):
+        """No escalation when position held but contract not expiring soon."""
+        from sysproduction.run_auto_roll_status import process_instrument_roll_status
+        from sysproduction.interactive_update_roll_status import RollDataWithStateReporting
+        
+        roll_data = RollDataWithStateReporting(
+            instrument_code="ES",
+            original_roll_status=RollState.Passive,
+            position_priced_contract=5,  # Has position
+            allowable_roll_states_as_list_of_str=['Roll_Adjusted', 'Passive', 'No_Roll', 'No_Open'],
+            days_until_roll=50,
+            relative_volume=2.0,
+            absolute_forward_volume=500,
+            days_until_expiry=60,  # Not expiring soon
+        )
+        mock_setup.return_value = roll_data
+        mock_suggest.return_value = RollState.Passive  # Same as current
+        
+        data = MagicMock()
+        auto_params = DEFAULT_PARAMS
+        
+        process_instrument_roll_status(
+            data=data, api=MagicMock(), instrument_code="ES",
+            auto_parameters=auto_params,
+        )
+        
+        # Should NOT log EXPIRY ESCALATION
+        escalation_logs = [
+            c for c in data.log.critical.call_args_list
+            if "EXPIRY ESCALATION" in str(c)
+        ]
+        assert len(escalation_logs) == 0
+
+    @patch("sysproduction.run_auto_roll_status.setup_roll_data_with_state_reporting")
+    @patch("sysproduction.run_auto_roll_status._roll_adjusted_blocked_by_expiring_positions")
+    @patch("sysproduction.run_auto_roll_status._log_auto_roll_position_diagnostics")
+    @patch("sysproduction.run_auto_roll_status.suggest_roll_state_for_instrument")
+    @patch("sysproduction.run_auto_roll_status.modify_roll_state")
+    def test_roll_adjusted_blocked_by_expiring_non_priced_position(
+        self, mock_modify, mock_suggest, mock_diag_log, mock_blocked, mock_setup
+    ):
+        """A zero priced-contract position must not hide an expiring non-priced DB leg."""
+        from sysproduction.run_auto_roll_status import process_instrument_roll_status
+        from sysproduction.interactive_update_roll_status import RollDataWithStateReporting
+
+        roll_data = RollDataWithStateReporting(
+            instrument_code="GASOILINE",
+            original_roll_status=RollState.Passive,
+            position_priced_contract=0,
+            allowable_roll_states_as_list_of_str=[
+                "Roll_Adjusted", "Passive", "No_Roll", "No_Open"
+            ],
+            days_until_roll=-30,
+            relative_volume=0.3661,
+            absolute_forward_volume=6204,
+            days_until_expiry=30,
+        )
+        mock_setup.return_value = roll_data
+        mock_suggest.return_value = RollState.Roll_Adjusted
+        mock_blocked.return_value = (
+            True,
+            "expiring DB contract positions exist despite zero priced-contract position",
+        )
+
+        data = MagicMock()
+
+        process_instrument_roll_status(
+            data=data,
+            api=MagicMock(),
+            instrument_code="GASOILINE",
+            auto_parameters=DEFAULT_PARAMS,
+        )
+
+        mock_modify.assert_not_called()
+        blocked_logs = [
+            c for c in data.log.critical.call_args_list
+            if "ROLL_ADJUSTED BLOCKED" in str(c)
+        ]
+        assert len(blocked_logs) == 1


### PR DESCRIPTION
## Summary

Adds `run_auto_roll_status`, a daily non-interactive process that automatically updates futures contract roll states. It plugs into the existing `processToRun` framework so it gets the same locking, start/stop window, dashboard monitoring, and MongoDB finish-status tracking as other production jobs.

The job is intended to run after multiple/adjusted prices are updated and before the stack handler, so roll decisions are based on fresh price data. It reuses the suggestion logic from `interactive_update_roll_status` (`autoRollParameters`, `suggest_roll_state_for_instrument`, `setup_roll_data_with_state_reporting`, `modify_roll_state`) so the interactive and automatic flows stay consistent.

## Companion changes in `interactive_update_roll_status`

- `include_instrument_in_auto_cycle` now keys off `days_until_price_expiry` only, matching the escalation check in `process_instrument_roll_status`. The previous `min(carry, roll, price)` could mask price expiry for instruments with negative `RollOffsetDays` (e.g., NASDAQ micro).
- New `check_if_any_key_contract_has_expired` helper widens auto-cycle selection to instruments where any current key contract (carry, priced, forward) has already expired, so dairy-style cases are no longer left for `update_sampled_contracts` to alert on without auto-roll seeing them.
- `RollDataWithStateReporting` gains an `any_key_contract_expired` flag for downstream reporting.

## What's included

- `sysproduction/run_auto_roll_status.py` — the new entry point + `updateAutoRollStatus` timer class.
- `sysproduction/interactive_update_roll_status.py` — auto-cycle inclusion / expiry-detection refactor described above.
- `docs/auto-roll-status.md` — operational guide: roll states, allowable transitions, configuration knobs, escalation logic.
- `tests/test_auto_roll_status.py` — covers suggestion branches, volume / time-boundary logic, expiry escalation (the gap that caused a real VIX position break), and `ASK_FOR_STATE` auto-resolution.

## Operational notes

This is intended to be wired into `control_config.yaml` and crontab alongside the other `run_*` jobs. The doc walks through the schedule and required config.

## Test plan

- [ ] `pytest tests/test_auto_roll_status.py`
- [ ] Dry run against a staging dataBlob (no real positions) and confirm process appears in dashboard, finish status lands in MongoDB
- [ ] Verify auto-cycle correctly picks up an instrument whose carry contract has already expired but price contract has not (dairy-style case)
- [ ] Confirm no behavior change for instruments outside the look-ahead window