### PR TITLE
Auto-cycle: key inclusion off priced-contract expiry only

### DIFF
--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -225,7 +225,7 @@ def get_days_ahead_to_consider_when_auto_cycling() -> int:
 
 
 def get_list_of_instruments_to_auto_cycle(data: dataBlob, days_ahead: int = 10) -> list:
-    diag_prices = diagPrices()
+    diag_prices = diagPrices(data)
     list_of_potential_instruments = (
         diag_prices.get_list_of_instruments_in_multiple_prices()
     )
@@ -248,17 +248,19 @@ def get_list_of_instruments_to_auto_cycle(data: dataBlob, days_ahead: int = 10) 
 def include_instrument_in_auto_cycle(
     data: dataBlob, instrument_code: str, days_ahead: int = 10
 ) -> bool:
-    days_until_expiry = days_until_earliest_expiry(data, instrument_code)
-    return days_until_expiry <= days_ahead
+    """
+    Returns True if the priced contract expires within ``days_ahead`` days.
 
-
-def days_until_earliest_expiry(data: dataBlob, instrument_code: str) -> int:
+    Keys off ``days_until_price_expiry`` so the selection criterion matches
+    the escalation check used downstream by ``process_instrument_roll_status``.
+    The previous ``min(carry, roll, price)`` could mask price expiry for
+    instruments with negative ``RollOffsetDays`` (e.g. NASDAQ micro), where
+    carry/roll days are already negative even though the priced contract is
+    still healthy.
+    """
     data_contracts = dataContracts(data)
-    carry_days = data_contracts.days_until_carry_expiry(instrument_code)
-    roll_days = data_contracts.days_until_roll(instrument_code)
-    price_days = data_contracts.days_until_price_expiry(instrument_code)
-
-    return min([carry_days, roll_days, price_days])
+    days_until_expiry = data_contracts.days_until_price_expiry(instrument_code)
+    return days_until_expiry <= days_ahead
 
 
 @dataclass


### PR DESCRIPTION
First of four PRs split out from #1629, per the suggestion in https://github.com/pst-group/pysystemtrade/pull/1629#issuecomment-4432546454 to land the changes to the interactive roll process separately from the new automatic wrapper.

## Summary

`include_instrument_in_auto_cycle` previously selected on
`min(days_until_carry_expiry, days_until_roll, days_until_price_expiry)`. For instruments with a negative `RollOffsetDays` (e.g. NASDAQ micro), `days_until_roll` and `days_until_carry_expiry` can already be negative even while the priced contract is still healthy — which then masks the priced-expiry check that `process_instrument_roll_status` actually escalates on.

Switch to `days_until_price_expiry` only, so the auto-cycle selection criterion matches the escalation check used downstream.

Also:

- Pass `data` into `diagPrices(...)` — it was constructing a fresh blob and ignoring the caller's connection / log context.
- Drop the now-unused `days_until_earliest_expiry` helper.
- Keep the existing "Identified following instruments…" summary print (addresses the review comment on the original PR).

## Why split out

PR #1629 bundled this with a new non-interactive auto-roll wrapper and a few other changes to `interactive_update_roll_status`. tgibson11 asked for the interactive changes to land separately, in pieces that can be reviewed in isolation. This is the first of those pieces.

## Stacked PRs

- **This PR** — `include_instrument_in_auto_cycle` selection fix.
- Next: `check_if_any_key_contract_has_expired` helper + `any_key_contract_expired` flag on `RollDataWithStateReporting` (builds on this one).
- Then: changes to `suggest_roll_state_for_instrument` (late-roll → `Force_Outright`, `No_Roll` fallback).
- Finally: the `run_auto_roll_status` wrapper itself.

## Test plan

- [ ] Existing tests still pass.
- [ ] Hand-trace `include_instrument_in_auto_cycle` for an instrument with negative `RollOffsetDays` and confirm it now flips True at the right threshold.