### PR TITLE
[DEFERRED] Auto-roll: detect expired key contracts in selection + roll data

### DIFF
--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -13,6 +13,7 @@ from syscore.interactive.input import (
 )
 from syscore.interactive.menus import print_menu_of_values_and_get_response
 from syscore.constants import named_object, status, success, failure
+from syscore.exceptions import ContractNotFound
 from syscore.interactive.display import (
     print_with_landing_strips_around,
     landing_strip,
@@ -40,7 +41,7 @@ from sysproduction.reporting.data.rolls import volume_contracts_in_forward_contr
 
 from sysproduction.data.positions import diagPositions, updatePositions
 from sysproduction.data.controls import updateOverrides, dataTradeLimits
-from sysproduction.data.contracts import dataContracts
+from sysproduction.data.contracts import dataContracts, FORWARD_SUFFIX
 from sysproduction.data.prices import diagPrices, get_valid_instrument_code_from_user
 
 from sysproduction.reporting.data.rolls import (
@@ -97,6 +98,7 @@ class RollDataWithStateReporting(object):
     relative_volume: float
     absolute_forward_volume: int
     days_until_expiry: int
+    any_key_contract_expired: bool = False
 
     @property
     def original_roll_status_as_string(self):
@@ -225,7 +227,7 @@ def get_days_ahead_to_consider_when_auto_cycling() -> int:
 
 
 def get_list_of_instruments_to_auto_cycle(data: dataBlob, days_ahead: int = 10) -> list:
-    diag_prices = diagPrices()
+    diag_prices = diagPrices(data)
     list_of_potential_instruments = (
         diag_prices.get_list_of_instruments_in_multiple_prices()
     )
@@ -249,7 +251,12 @@ def include_instrument_in_auto_cycle(
     data: dataBlob, instrument_code: str, days_ahead: int = 10
 ) -> bool:
     days_until_expiry = days_until_earliest_expiry(data, instrument_code)
-    return days_until_expiry <= days_ahead
+    if days_until_expiry <= days_ahead:
+        return True
+
+    return check_if_any_key_contract_has_expired(
+        data=data, instrument_code=instrument_code
+    )
 
 
 def days_until_earliest_expiry(data: dataBlob, instrument_code: str) -> int:
@@ -259,6 +266,55 @@ def days_until_earliest_expiry(data: dataBlob, instrument_code: str) -> int:
     price_days = data_contracts.days_until_price_expiry(instrument_code)
 
     return min([carry_days, roll_days, price_days])
+
+
+def check_if_any_key_contract_has_expired(
+    data: dataBlob, instrument_code: str
+) -> bool:
+    """
+    True if any current key contract (carry/priced/forward) has already expired.
+
+    Selection on the (carry, roll, price) day windows can miss an instrument
+    whose carry contract is already expired but whose priced contract is still
+    outside the look-ahead window. update_sampled_contracts will alert on that
+    case; this check lets auto-roll see it before the morning checker fires.
+
+    ContractNotFound is tolerated only for the forward leg: a fresh
+    Roll_Adjusted advances the forward slot in the multiple-prices chain
+    before update_sampled_contracts writes the new contract, so an unsampled
+    forward is expected. Missing carry or priced contracts log critical
+    instead, since they should always exist.
+    """
+    data_contracts = dataContracts(data)
+    labelled_contracts = data_contracts.get_labelled_dict_of_current_contracts(
+        instrument_code
+    )
+    key_contract_ids = labelled_contracts["contracts"]
+    key_contract_labels = labelled_contracts["labels"]
+
+    for contract_id, label in zip(key_contract_ids, key_contract_labels):
+        contract = futuresContract(instrument_code, contract_id)
+        try:
+            actual_contract = data_contracts.get_contract_from_db(contract)
+        except ContractNotFound:
+            if label.endswith(FORWARD_SUFFIX):
+                data.log.debug(
+                    "Forward contract %s/%s not yet sampled in DB; "
+                    "treating as not-expired for auto-roll selection"
+                    % (instrument_code, contract_id)
+                )
+                continue
+            data.log.critical(
+                "Key contract %s/%s (%s) referenced by multiple-prices but "
+                "missing from contracts DB - investigate (delisted? manually "
+                "deleted? stale multiple-prices entry?). Skipping expiry "
+                "check for this leg." % (instrument_code, contract_id, label)
+            )
+            continue
+        if actual_contract.expired():
+            return True
+
+    return False
 
 
 @dataclass
@@ -658,6 +714,9 @@ def setup_roll_data_with_state_reporting(
 
     days_until_roll = diag_contracts.days_until_roll(instrument_code)
     days_until_expiry = diag_contracts.days_until_price_expiry(instrument_code)
+    any_key_contract_expired = check_if_any_key_contract_has_expired(
+        data=data, instrument_code=instrument_code
+    )
 
     relative_volume = relative_volume_in_forward_contract_versus_price(
         data=data, instrument_code=instrument_code
@@ -679,6 +738,7 @@ def setup_roll_data_with_state_reporting(
         relative_volume=relative_volume,
         absolute_forward_volume=absolute_forward_volume,
         days_until_expiry=days_until_expiry,
+        any_key_contract_expired=any_key_contract_expired,
     )
 
     return roll_data_with_state

--- a/sysproduction/tests/test_interactive_update_roll_status.py
+++ b/sysproduction/tests/test_interactive_update_roll_status.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Google LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Unit tests for the auto-cycle selection helpers in interactive_update_roll_status.
+
+Covers:
+  * include_instrument_in_auto_cycle - the (carry, roll, price) day-window
+    union check, plus the OR-d "any key contract expired" safety net.
+  * check_if_any_key_contract_has_expired - iteration over labelled
+    carry/priced/forward contracts, ContractNotFound tolerance for the
+    forward leg only, critical log for missing carry/priced.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from syscore.exceptions import ContractNotFound
+from sysproduction.interactive_update_roll_status import (
+    check_if_any_key_contract_has_expired,
+    include_instrument_in_auto_cycle,
+)
+
+
+def _make_data_blob():
+    data = MagicMock()
+    data.log = MagicMock()
+    return data
+
+
+def _patch_data_contracts(monkeypatch, instance):
+    """
+    interactive_update_roll_status constructs `dataContracts(data)` inside the
+    helpers. Patch that constructor so each call returns our mock.
+    """
+    monkeypatch.setattr(
+        "sysproduction.interactive_update_roll_status.dataContracts",
+        lambda _data: instance,
+    )
+
+
+# ---------------------------------------------------------------------------
+# include_instrument_in_auto_cycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "carry_days,roll_days,price_days",
+    [
+        (5, 50, 50),   # carry alarm
+        (50, 5, 50),   # roll alarm
+        (50, 50, 5),   # price alarm
+    ],
+)
+def test_include_when_any_window_alarm_fires(monkeypatch, carry_days, roll_days, price_days):
+    """Selection should fire for the union of (carry, roll, price) windows."""
+    contracts = MagicMock()
+    contracts.days_until_carry_expiry.return_value = carry_days
+    contracts.days_until_roll.return_value = roll_days
+    contracts.days_until_price_expiry.return_value = price_days
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert include_instrument_in_auto_cycle(
+        data=_make_data_blob(), instrument_code="X", days_ahead=10
+    ) is True
+
+
+def test_include_when_no_window_alarm_but_key_contract_expired(monkeypatch):
+    """Smoke detector fires even when all three day windows are clear."""
+    contracts = MagicMock()
+    contracts.days_until_carry_expiry.return_value = 50
+    contracts.days_until_roll.return_value = 50
+    contracts.days_until_price_expiry.return_value = 50
+
+    expired_carry = MagicMock()
+    expired_carry.expired.return_value = True
+    contracts.get_contract_from_db.return_value = expired_carry
+
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260100", "20260700", "20260800"],
+        "labels": ["20260100c", "20260700p", "20260800f"],
+    }
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert include_instrument_in_auto_cycle(
+        data=_make_data_blob(), instrument_code="X", days_ahead=10
+    ) is True
+
+
+def test_exclude_when_nothing_fires(monkeypatch):
+    """Neither alarm nor smoke detector -> excluded."""
+    contracts = MagicMock()
+    contracts.days_until_carry_expiry.return_value = 50
+    contracts.days_until_roll.return_value = 50
+    contracts.days_until_price_expiry.return_value = 50
+
+    healthy = MagicMock()
+    healthy.expired.return_value = False
+    contracts.get_contract_from_db.return_value = healthy
+
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260700", "20260800", "20260900"],
+        "labels": ["20260700c", "20260800p", "20260900f"],
+    }
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert include_instrument_in_auto_cycle(
+        data=_make_data_blob(), instrument_code="X", days_ahead=10
+    ) is False
+
+
+def test_window_alarm_short_circuits_smoke_detector(monkeypatch):
+    """If the day-window alarm fires we should not bother iterating contracts."""
+    contracts = MagicMock()
+    contracts.days_until_carry_expiry.return_value = 1
+    contracts.days_until_roll.return_value = 50
+    contracts.days_until_price_expiry.return_value = 50
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert include_instrument_in_auto_cycle(
+        data=_make_data_blob(), instrument_code="X", days_ahead=10
+    ) is True
+    contracts.get_labelled_dict_of_current_contracts.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# check_if_any_key_contract_has_expired
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_detector_true_when_any_leg_expired(monkeypatch):
+    contracts = MagicMock()
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260100", "20260700", "20260800"],
+        "labels": ["20260100c", "20260700p", "20260800f"],
+    }
+
+    fresh = MagicMock(); fresh.expired.return_value = False
+    expired = MagicMock(); expired.expired.return_value = True
+    contracts.get_contract_from_db.side_effect = [fresh, expired, fresh]
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert check_if_any_key_contract_has_expired(
+        data=_make_data_blob(), instrument_code="X"
+    ) is True
+
+
+def test_smoke_detector_false_when_all_legs_fresh(monkeypatch):
+    contracts = MagicMock()
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260700", "20260800", "20260900"],
+        "labels": ["20260700c", "20260800p", "20260900f"],
+    }
+    fresh = MagicMock(); fresh.expired.return_value = False
+    contracts.get_contract_from_db.return_value = fresh
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert check_if_any_key_contract_has_expired(
+        data=_make_data_blob(), instrument_code="X"
+    ) is False
+
+
+def test_smoke_detector_tolerates_unsampled_forward(monkeypatch):
+    """ContractNotFound on the forward leg is expected after a fresh Roll_Adjusted."""
+    contracts = MagicMock()
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260700", "20260800", "20260900"],
+        "labels": ["20260700c", "20260800p", "20260900f"],
+    }
+    fresh = MagicMock(); fresh.expired.return_value = False
+
+    def side_effect(contract):
+        if contract.date_str == "20260900":
+            raise ContractNotFound("forward not yet sampled")
+        return fresh
+
+    contracts.get_contract_from_db.side_effect = side_effect
+    _patch_data_contracts(monkeypatch, contracts)
+
+    data = _make_data_blob()
+    assert check_if_any_key_contract_has_expired(
+        data=data, instrument_code="X"
+    ) is False
+    data.log.critical.assert_not_called()
+    data.log.debug.assert_called()
+
+
+def test_smoke_detector_logs_critical_for_missing_priced(monkeypatch):
+    """ContractNotFound on the priced leg should not be silently swallowed."""
+    contracts = MagicMock()
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260700", "20260800", "20260900"],
+        "labels": ["20260700c", "20260800p", "20260900f"],
+    }
+    fresh = MagicMock(); fresh.expired.return_value = False
+
+    def side_effect(contract):
+        if contract.date_str == "20260800":  # priced
+            raise ContractNotFound("priced missing from DB")
+        return fresh
+
+    contracts.get_contract_from_db.side_effect = side_effect
+    _patch_data_contracts(monkeypatch, contracts)
+
+    data = _make_data_blob()
+    assert check_if_any_key_contract_has_expired(
+        data=data, instrument_code="X"
+    ) is False
+    data.log.critical.assert_called_once()


### PR DESCRIPTION
Second of four PRs split out from #1629.

> **Depends on #1630** — built on top of that branch. The diff against `develop` therefore includes both PRs' commits; please review the most recent commit (`Auto-roll: detect expired key contracts in selection + roll data`) in isolation.

## Summary

Adds `check_if_any_key_contract_has_expired`, which walks the carry/priced/forward contracts referenced by the multiple-price series and returns True if any has already expired. Wires it into:

- `include_instrument_in_auto_cycle`, so an expired carry leg is caught by auto-roll even when the priced contract is still beyond the look-ahead window. (Real case I hit: dairy-style instruments where `update_sampled_contracts` was the only thing flagging an expired carry, and auto-roll never saw it.)
- `setup_roll_data_with_state_reporting`, populating a new `any_key_contract_expired: bool` field on `RollDataWithStateReporting` for downstream consumers.

`ContractNotFound` is tolerated only for the forward leg: a fresh `Roll_Adjusted` advances the forward slot in the multiple-prices chain before `update_sampled_contracts` writes the new contract, so an unsampled forward is expected. Missing carry or priced contracts log `critical` instead, since they should always exist and silently skipping them would mask a delisted contract or a corrupt multiple-prices entry.

## Why split out

Splitting #1629 per https://github.com/pst-group/pysystemtrade/pull/1629#issuecomment-4432546454. This is the expired-key detection in isolation.

## Test plan

- [ ] Existing tests pass.
- [ ] Manual: instrument with an already-expired carry contract and a healthy priced contract is selected by `get_list_of_instruments_to_auto_cycle`.
- [ ] Manual: a freshly-rolled instrument (forward slot not yet sampled) does not raise `ContractNotFound`.