### PR TITLE
Auto-roll: late-roll escalation, expired-key branch, No_Roll fallback

### DIFF
--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -268,9 +268,7 @@ def days_until_earliest_expiry(data: dataBlob, instrument_code: str) -> int:
     return min([carry_days, roll_days, price_days])
 
 
-def check_if_any_key_contract_has_expired(
-    data: dataBlob, instrument_code: str
-) -> bool:
+def check_if_any_key_contract_has_expired(data: dataBlob, instrument_code: str) -> bool:
     """
     True if any current key contract (carry/priced/forward) has already expired.
 

--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -13,6 +13,7 @@ from syscore.interactive.input import (
 )
 from syscore.interactive.menus import print_menu_of_values_and_get_response
 from syscore.constants import named_object, status, success, failure
+from syscore.exceptions import ContractNotFound
 from syscore.interactive.display import (
     print_with_landing_strips_around,
     landing_strip,
@@ -40,7 +41,7 @@ from sysproduction.reporting.data.rolls import volume_contracts_in_forward_contr
 
 from sysproduction.data.positions import diagPositions, updatePositions
 from sysproduction.data.controls import updateOverrides, dataTradeLimits
-from sysproduction.data.contracts import dataContracts
+from sysproduction.data.contracts import dataContracts, FORWARD_SUFFIX
 from sysproduction.data.prices import diagPrices, get_valid_instrument_code_from_user
 
 from sysproduction.reporting.data.rolls import (
@@ -97,6 +98,7 @@ class RollDataWithStateReporting(object):
     relative_volume: float
     absolute_forward_volume: int
     days_until_expiry: int
+    any_key_contract_expired: bool = False
 
     @property
     def original_roll_status_as_string(self):
@@ -225,7 +227,7 @@ def get_days_ahead_to_consider_when_auto_cycling() -> int:
 
 
 def get_list_of_instruments_to_auto_cycle(data: dataBlob, days_ahead: int = 10) -> list:
-    diag_prices = diagPrices()
+    diag_prices = diagPrices(data)
     list_of_potential_instruments = (
         diag_prices.get_list_of_instruments_in_multiple_prices()
     )
@@ -249,7 +251,12 @@ def include_instrument_in_auto_cycle(
     data: dataBlob, instrument_code: str, days_ahead: int = 10
 ) -> bool:
     days_until_expiry = days_until_earliest_expiry(data, instrument_code)
-    return days_until_expiry <= days_ahead
+    if days_until_expiry <= days_ahead:
+        return True
+
+    return check_if_any_key_contract_has_expired(
+        data=data, instrument_code=instrument_code
+    )
 
 
 def days_until_earliest_expiry(data: dataBlob, instrument_code: str) -> int:
@@ -259,6 +266,55 @@ def days_until_earliest_expiry(data: dataBlob, instrument_code: str) -> int:
     price_days = data_contracts.days_until_price_expiry(instrument_code)
 
     return min([carry_days, roll_days, price_days])
+
+
+def check_if_any_key_contract_has_expired(
+    data: dataBlob, instrument_code: str
+) -> bool:
+    """
+    True if any current key contract (carry/priced/forward) has already expired.
+
+    Selection on the (carry, roll, price) day windows can miss an instrument
+    whose carry contract is already expired but whose priced contract is still
+    outside the look-ahead window. update_sampled_contracts will alert on that
+    case; this check lets auto-roll see it before the morning checker fires.
+
+    ContractNotFound is tolerated only for the forward leg: a fresh
+    Roll_Adjusted advances the forward slot in the multiple-prices chain
+    before update_sampled_contracts writes the new contract, so an unsampled
+    forward is expected. Missing carry or priced contracts log critical
+    instead, since they should always exist.
+    """
+    data_contracts = dataContracts(data)
+    labelled_contracts = data_contracts.get_labelled_dict_of_current_contracts(
+        instrument_code
+    )
+    key_contract_ids = labelled_contracts["contracts"]
+    key_contract_labels = labelled_contracts["labels"]
+
+    for contract_id, label in zip(key_contract_ids, key_contract_labels):
+        contract = futuresContract(instrument_code, contract_id)
+        try:
+            actual_contract = data_contracts.get_contract_from_db(contract)
+        except ContractNotFound:
+            if label.endswith(FORWARD_SUFFIX):
+                data.log.debug(
+                    "Forward contract %s/%s not yet sampled in DB; "
+                    "treating as not-expired for auto-roll selection"
+                    % (instrument_code, contract_id)
+                )
+                continue
+            data.log.critical(
+                "Key contract %s/%s (%s) referenced by multiple-prices but "
+                "missing from contracts DB - investigate (delisted? manually "
+                "deleted? stale multiple-prices entry?). Skipping expiry "
+                "check for this leg." % (instrument_code, contract_id, label)
+            )
+            continue
+        if actual_contract.expired():
+            return True
+
+    return False
 
 
 @dataclass
@@ -658,6 +714,9 @@ def setup_roll_data_with_state_reporting(
 
     days_until_roll = diag_contracts.days_until_roll(instrument_code)
     days_until_expiry = diag_contracts.days_until_price_expiry(instrument_code)
+    any_key_contract_expired = check_if_any_key_contract_has_expired(
+        data=data, instrument_code=instrument_code
+    )
 
     relative_volume = relative_volume_in_forward_contract_versus_price(
         data=data, instrument_code=instrument_code
@@ -679,6 +738,7 @@ def setup_roll_data_with_state_reporting(
         relative_volume=relative_volume,
         absolute_forward_volume=absolute_forward_volume,
         days_until_expiry=days_until_expiry,
+        any_key_contract_expired=any_key_contract_expired,
     )
 
     return roll_data_with_state

--- a/sysproduction/interactive_update_roll_status.py
+++ b/sysproduction/interactive_update_roll_status.py
@@ -512,9 +512,31 @@ def suggest_roll_state_for_instrument(
     expired_and_auto_rolling_expired = check_if_expired_and_auto_rolling_expired(
         roll_data=roll_data, auto_parameters=auto_parameters
     )
+    key_contract_expired_and_auto_rolling_expired = (
+        roll_data.any_key_contract_expired and auto_parameters.auto_roll_expired
+    )
 
-    if expired_and_auto_rolling_expired and no_position_held:
-        ## contract expired so roll regardless of liquidity
+    # Late-roll escalation: a position is held and the desired roll date has
+    # already passed. Escalate to Force_Outright (always tradeable as an
+    # outright close) rather than Force, since many instruments don't have a
+    # liquid calendar spread and would silently get stuck. Don't downgrade
+    # urgency: if we're already in Force, Force_Outright or Close, keep it.
+    past_desired_roll_date = roll_data.days_until_roll < 0
+    if past_desired_roll_date and not no_position_held:
+        current_state = roll_data.original_roll_status
+        if current_state in (
+            RollState.Force,
+            RollState.Force_Outright,
+            RollState.Close,
+        ):
+            return current_state
+        return RollState.Force_Outright
+
+    if (
+        expired_and_auto_rolling_expired
+        or key_contract_expired_and_auto_rolling_expired
+    ) and no_position_held:
+        ## priced/key contract expired so roll regardless of liquidity
         return RollState.Roll_Adjusted
 
     if forward_liquid:
@@ -542,7 +564,14 @@ def suggest_roll_state_for_instrument(
             return RollState.No_Open
         else:
             ## forward illiquid and miles away. Don't roll yet.
-            return RollState.No_Roll
+            # No_Roll is not always a valid transition from the current state
+            # (e.g. No_Open only permits Roll_Adjusted / Passive / No_Open).
+            # Fall back to the current state when No_Roll is not allowable.
+            allowable = roll_data.allowable_roll_states_as_list_of_str
+            if RollState.No_Roll.name in allowable:
+                return RollState.No_Roll
+            else:
+                return roll_data.original_roll_status
 
 
 def check_if_forward_liquid(

--- a/sysproduction/tests/test_interactive_update_roll_status.py
+++ b/sysproduction/tests/test_interactive_update_roll_status.py
@@ -1,0 +1,208 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""
+Unit tests for the auto-cycle selection helpers in interactive_update_roll_status.
+
+Covers:
+  * include_instrument_in_auto_cycle - the (carry, roll, price) day-window
+    union check, plus the OR-d "any key contract expired" safety net.
+  * check_if_any_key_contract_has_expired - iteration over labelled
+    carry/priced/forward contracts, ContractNotFound tolerance for the
+    forward leg only, critical log for missing carry/priced.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from syscore.exceptions import ContractNotFound
+from sysproduction.interactive_update_roll_status import (
+    check_if_any_key_contract_has_expired,
+    include_instrument_in_auto_cycle,
+)
+
+
+def _make_data_blob():
+    data = MagicMock()
+    data.log = MagicMock()
+    return data
+
+
+def _patch_data_contracts(monkeypatch, instance):
+    """
+    interactive_update_roll_status constructs `dataContracts(data)` inside the
+    helpers. Patch that constructor so each call returns our mock.
+    """
+    monkeypatch.setattr(
+        "sysproduction.interactive_update_roll_status.dataContracts",
+        lambda _data: instance,
+    )
+
+
+# ---------------------------------------------------------------------------
+# include_instrument_in_auto_cycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "carry_days,roll_days,price_days",
+    [
+        (5, 50, 50),   # carry alarm
+        (50, 5, 50),   # roll alarm
+        (50, 50, 5),   # price alarm
+    ],
+)
+def test_include_when_any_window_alarm_fires(monkeypatch, carry_days, roll_days, price_days):
+    """Selection should fire for the union of (carry, roll, price) windows."""
+    contracts = MagicMock()
+    contracts.days_until_carry_expiry.return_value = carry_days
+    contracts.days_until_roll.return_value = roll_days
+    contracts.days_until_price_expiry.return_value = price_days
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert include_instrument_in_auto_cycle(
+        data=_make_data_blob(), instrument_code="X", days_ahead=10
+    ) is True
+
+
+def test_include_when_no_window_alarm_but_key_contract_expired(monkeypatch):
+    """Smoke detector fires even when all three day windows are clear."""
+    contracts = MagicMock()
+    contracts.days_until_carry_expiry.return_value = 50
+    contracts.days_until_roll.return_value = 50
+    contracts.days_until_price_expiry.return_value = 50
+
+    expired_carry = MagicMock()
+    expired_carry.expired.return_value = True
+    contracts.get_contract_from_db.return_value = expired_carry
+
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260100", "20260700", "20260800"],
+        "labels": ["20260100c", "20260700p", "20260800f"],
+    }
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert include_instrument_in_auto_cycle(
+        data=_make_data_blob(), instrument_code="X", days_ahead=10
+    ) is True
+
+
+def test_exclude_when_nothing_fires(monkeypatch):
+    """Neither alarm nor smoke detector -> excluded."""
+    contracts = MagicMock()
+    contracts.days_until_carry_expiry.return_value = 50
+    contracts.days_until_roll.return_value = 50
+    contracts.days_until_price_expiry.return_value = 50
+
+    healthy = MagicMock()
+    healthy.expired.return_value = False
+    contracts.get_contract_from_db.return_value = healthy
+
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260700", "20260800", "20260900"],
+        "labels": ["20260700c", "20260800p", "20260900f"],
+    }
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert include_instrument_in_auto_cycle(
+        data=_make_data_blob(), instrument_code="X", days_ahead=10
+    ) is False
+
+
+def test_window_alarm_short_circuits_smoke_detector(monkeypatch):
+    """If the day-window alarm fires we should not bother iterating contracts."""
+    contracts = MagicMock()
+    contracts.days_until_carry_expiry.return_value = 1
+    contracts.days_until_roll.return_value = 50
+    contracts.days_until_price_expiry.return_value = 50
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert include_instrument_in_auto_cycle(
+        data=_make_data_blob(), instrument_code="X", days_ahead=10
+    ) is True
+    contracts.get_labelled_dict_of_current_contracts.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# check_if_any_key_contract_has_expired
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_detector_true_when_any_leg_expired(monkeypatch):
+    contracts = MagicMock()
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260100", "20260700", "20260800"],
+        "labels": ["20260100c", "20260700p", "20260800f"],
+    }
+
+    fresh = MagicMock(); fresh.expired.return_value = False
+    expired = MagicMock(); expired.expired.return_value = True
+    contracts.get_contract_from_db.side_effect = [fresh, expired, fresh]
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert check_if_any_key_contract_has_expired(
+        data=_make_data_blob(), instrument_code="X"
+    ) is True
+
+
+def test_smoke_detector_false_when_all_legs_fresh(monkeypatch):
+    contracts = MagicMock()
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260700", "20260800", "20260900"],
+        "labels": ["20260700c", "20260800p", "20260900f"],
+    }
+    fresh = MagicMock(); fresh.expired.return_value = False
+    contracts.get_contract_from_db.return_value = fresh
+    _patch_data_contracts(monkeypatch, contracts)
+
+    assert check_if_any_key_contract_has_expired(
+        data=_make_data_blob(), instrument_code="X"
+    ) is False
+
+
+def test_smoke_detector_tolerates_unsampled_forward(monkeypatch):
+    """ContractNotFound on the forward leg is expected after a fresh Roll_Adjusted."""
+    contracts = MagicMock()
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260700", "20260800", "20260900"],
+        "labels": ["20260700c", "20260800p", "20260900f"],
+    }
+    fresh = MagicMock(); fresh.expired.return_value = False
+
+    def side_effect(contract):
+        if contract.date_str == "20260900":
+            raise ContractNotFound("forward not yet sampled")
+        return fresh
+
+    contracts.get_contract_from_db.side_effect = side_effect
+    _patch_data_contracts(monkeypatch, contracts)
+
+    data = _make_data_blob()
+    assert check_if_any_key_contract_has_expired(
+        data=data, instrument_code="X"
+    ) is False
+    data.log.critical.assert_not_called()
+    data.log.debug.assert_called()
+
+
+def test_smoke_detector_logs_critical_for_missing_priced(monkeypatch):
+    """ContractNotFound on the priced leg should not be silently swallowed."""
+    contracts = MagicMock()
+    contracts.get_labelled_dict_of_current_contracts.return_value = {
+        "contracts": ["20260700", "20260800", "20260900"],
+        "labels": ["20260700c", "20260800p", "20260900f"],
+    }
+    fresh = MagicMock(); fresh.expired.return_value = False
+
+    def side_effect(contract):
+        if contract.date_str == "20260800":  # priced
+            raise ContractNotFound("priced missing from DB")
+        return fresh
+
+    contracts.get_contract_from_db.side_effect = side_effect
+    _patch_data_contracts(monkeypatch, contracts)
+
+    data = _make_data_blob()
+    assert check_if_any_key_contract_has_expired(
+        data=data, instrument_code="X"
+    ) is False
+    data.log.critical.assert_called_once()


### PR DESCRIPTION
Third of four PRs split out from #1629. Also addresses two of the inline review comments on that PR directly.

> **Depends on #1630 and #1631** — built on top of those branches. The diff against `develop` includes their commits; please review the latest commit (`Auto-roll: late-roll escalation, expired-key branch, No_Roll fallback`) in isolation.

## Summary

Three changes to `suggest_roll_state_for_instrument`, each motivated by a real production state I'd been hitting.

### 1. Late-roll escalation → `Force_Outright`

If a position is held and we're already past the desired roll date (`days_until_roll < 0`), escalate to `Force_Outright` rather than `Force`. `Force` requires a tradeable calendar spread, which a lot of the universe doesn't have, so it can silently get stuck. `Force_Outright` always works as an outright close.

Don't downgrade urgency: if the current state is already `Force`, `Force_Outright` or `Close`, keep it.

(This addresses tgibson11's review comment on #1629 — https://github.com/pst-group/pysystemtrade/pull/1629#discussion_r3227865691. The original PR used `Force` here; this version uses `Force_Outright`.)

### 2. Key-contract-expired branch

Honour the new `roll_data.any_key_contract_expired` flag (from #1631) the same way `expired_and_auto_rolling_expired` is honoured — roll regardless of liquidity when no position is held and `auto_roll_expired` is enabled.

### 3. `No_Roll` fallback when not allowable

`No_Roll` is not always a valid transition from the current state (e.g. `No_Open` only permits `Roll_Adjusted` / `Passive` / `No_Open`). Fall back to the current state in that case rather than returning a state that the downstream transition check will reject — previously this could leave some instruments effectively un-suggested.

(Confirmed-worthwhile by tgibson11 at https://github.com/pst-group/pysystemtrade/pull/1629#discussion_r3227902987.)

### What's not in this PR

The original #1629 also had an "early passive" branch in `suggest_roll_state_for_instrument` that flipped to `Passive` if a position was held inside the passive-start window and the forward had any volume. tgibson11 flagged that the `volume > 0` gate was too loose (https://github.com/pst-group/pysystemtrade/pull/1629#discussion_r3227888030). Rather than retune the threshold, I've **dropped the early-passive branch entirely** here — `Passive` is now only suggested once the forward is actually liquid per `check_if_forward_liquid`. Happy to revisit in a follow-up if there's a use case where waiting for full liquidity leads to bad fills at expiry.

## Test plan

- [ ] Existing tests pass.
- [ ] Late-roll: position held + `days_until_roll < 0` + current state `No_Roll` → suggests `Force_Outright` (not `Force`).
- [ ] Late-roll downgrade guard: same scenario but current state already `Close` → stays `Close`.
- [ ] Forward illiquid, far from roll, current state `No_Open` (where `No_Roll` is not allowable) → returns current state, not `No_Roll`.