### PR TITLE
Return empty mean instead of empty stdev when no data before fit end.

### DIFF
--- a/sysquant/estimators/mean_estimator.py
+++ b/sysquant/estimators/mean_estimator.py
@@ -76,7 +76,7 @@ class exponentialMeans(exponentialEstimator):
             exponential_mean_df.index, fit_period.fit_end
         )
         if last_index is None:
-            return empty_stdev(self.data)
+            return empty_mean(self.data)
 
         mean = meanEstimates(exponential_mean_df.iloc[last_index])
         mean = annualise_mean_estimate(mean, frequency=self.frequency)

--- a/sysquant/estimators/tests/test_mean_estimator.py
+++ b/sysquant/estimators/tests/test_mean_estimator.py
@@ -1,0 +1,35 @@
+"""
+Created on 17 May 2026
+
+@author: javierdejesusda
+"""
+import datetime
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from sysquant.estimators.mean_estimator import exponentialMeans, meanEstimates
+from sysquant.fitting_dates import fitDates
+
+
+class Test(unittest.TestCase):
+    def test_estimate_before_any_data_returns_empty_mean(self):
+        index = pd.date_range(datetime.datetime(2020, 1, 1), periods=50, freq="W")
+        data = pd.DataFrame({"a": np.arange(50.0), "b": np.arange(50.0)}, index=index)
+
+        estimator = exponentialMeans(data)
+
+        before_data = datetime.datetime(2019, 1, 1)
+        fit_period = fitDates(before_data, before_data, before_data, before_data)
+
+        estimate = estimator.get_estimate_for_fitperiod_with_data(fit_period)
+
+        self.assertIsInstance(estimate, meanEstimates)
+        self.assertEqual(estimate.list_of_keys(), ["a", "b"])
+        self.assertTrue(np.isnan(estimate["a"]))
+        self.assertTrue(np.isnan(estimate["b"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1616

`exponentialMeans.get_estimate_for_fitperiod_with_data()` returned `empty_stdev(self.data)` when there was no data before the fit end date. `empty_stdev` is not imported in `mean_estimator.py`, so that path raised `NameError` instead of returning a mean estimate. Changed it to `empty_mean()`, which returns a `meanEstimates` of NaNs and matches both the equivalent stdev estimator and `meanEstimator.estimate_if_no_data()`. Added a test for the no-data-before-fit-end path.
