### PR TITLE
Bug fix - Issue #1637 - Index overwritten instead of column names

### DIFF
--- a/systems/accounts/pandl_calculators/pandl_cash_costs.py
+++ b/systems/accounts/pandl_calculators/pandl_cash_costs.py
@@ -43,7 +43,7 @@ class pandlCalculationWithCashCostsAndFills(
         net = self.net_pandl_in_instrument_currency()
 
         calculations_df = pd.concat([pandl, costs, net], axis=1)
-        calculations_df.index = ["gross", "costs", "net"]
+        calculations_df.columns = ["gross", "costs", "net"]
 
         return calculations_df
 


### PR DESCRIPTION
Very small bug in pandl_cash_costs.py line 46 identified by issue #1637.

Original code was setting index instead of column names.

The Black linter was run and all unit tests passed.