### PR TITLE
Bug 1390 covariance instead of correlation

### DIFF
--- a/sysquant/estimators/estimates.py
+++ b/sysquant/estimators/estimates.py
@@ -46,6 +46,10 @@ class Estimates:
     @property
     def correlation_matrix(self) -> np.array:
         return self.correlation.values
+    
+    @property
+    def covariance_matrix(self) -> np.array:
+        return self.correlation.values * np.array(self.stdev_list) * np.array(self.stdev_list).reshape(-1, 1)
 
     @property
     def data_length_years(self) -> float:

--- a/sysquant/estimators/estimates.py
+++ b/sysquant/estimators/estimates.py
@@ -46,10 +46,14 @@ class Estimates:
     @property
     def correlation_matrix(self) -> np.array:
         return self.correlation.values
-    
+
     @property
     def covariance_matrix(self) -> np.array:
-        return self.correlation.values * np.array(self.stdev_list) * np.array(self.stdev_list).reshape(-1, 1)
+        return (
+            self.correlation.values
+            * np.array(self.stdev_list)
+            * np.array(self.stdev_list).reshape(-1, 1)
+        )
 
     @property
     def data_length_years(self) -> float:

--- a/systems/provided/static_small_system_optimise/optimise_small_system.py
+++ b/systems/provided/static_small_system_optimise/optimise_small_system.py
@@ -191,7 +191,7 @@ def estimate_SR_given_weights(
 
     wt = np.array(risk_weights.as_list_given_keys(instrument_list))
     mu = np.array(mean_estimates.list_in_key_order(instrument_list))
-    cm = handcraft_portfolio.estimates.correlation_matrix
+    cm = handcraft_portfolio.estimates.covariance_matrix
 
     SR = -neg_SR(wt, cm, mu)
 


### PR DESCRIPTION
Fixes #1390 

The function `estimates_SR_given_weights()` uses three variables `wt, mu, cm` to calculate the portfolio SR with `neg_SR()`. The variable `cm` is the correlation matrix instead of the covariance matrix. Since the standard deviations are normalized to 1, it still works however the comment in issue #1390 mentions that fixing it is worthwhile and may be useful for future code improvements.
