### PR TITLE
Fix sign error in SR cost adjustment (#1644)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ testpaths = [
     "sysobjects/tests",
     # "sysquant/estimators",
     "sysquant/optimisation",
+    "sysquant/tests",
     # "systems",
     # "systems/accounts",
     # "systems/provided",

--- a/sysquant/returns.py
+++ b/sysquant/returns.py
@@ -164,7 +164,7 @@ def _adjust_df_column_for_SR_costs(
     daily_gross_return_std = daily_gross_returns_for_column.std()
     daily_SR_cost = dict_of_SR_costs[column_name] / ROOT_BDAYS_INYEAR
 
-    daily_returns_cost = -daily_SR_cost * daily_gross_return_std
+    daily_returns_cost = daily_SR_cost * daily_gross_return_std
 
     daily_returns_cost_as_list = [daily_returns_cost] * len(gross_returns.index)
     daily_returns_cost_as_ts = pd.Series(

--- a/sysquant/tests/test_returns.py
+++ b/sysquant/tests/test_returns.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for the sign convention used when applying SR (Sharpe Ratio)
+costs to gross returns.
+
+See GitHub issue #1644: `_adjust_df_column_for_SR_costs` was flipping the
+sign of an already-negative `daily_SR_cost`, so applying trading costs made
+net returns *higher* than gross returns instead of lower.
+"""
+import datetime
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from sysquant.returns import (
+    _adjust_df_column_for_SR_costs,
+    _adjust_df_for_SR_costs,
+    dictOfSR,
+)
+from syscore.dateutils import ROOT_BDAYS_INYEAR
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        # Deterministic, non-degenerate gross return series (need std > 0)
+        np.random.seed(42)
+        index = pd.bdate_range(datetime.datetime(2020, 1, 1), periods=250)
+        values = np.random.normal(loc=0.0, scale=2.5, size=len(index))
+        self.gross_returns = pd.DataFrame({"instrument_a": values}, index=index)
+
+    def test_negative_SR_cost_reduces_every_days_return(self):
+        # A cost curve's daily mean is inherently negative (it is a drag on
+        # P&L), so its annualised SR is negative too - this is the sign
+        # convention produced upstream by
+        # sysquant.returns._get_annual_SR_for_returns_for_optimisation(type="costs").
+        dict_of_SR_costs = dictOfSR({"instrument_a": -0.5})
+
+        net_returns = _adjust_df_column_for_SR_costs(
+            self.gross_returns, dict_of_SR_costs, "instrument_a"
+        )
+
+        gross_column = self.gross_returns["instrument_a"]
+
+        # Costs must drag the whole return series down, not up: every day's
+        # net return should be strictly lower than the matching gross return.
+        self.assertTrue((net_returns < gross_column).all())
+
+        # And the aggregate effect should also show net performance below
+        # gross performance.
+        self.assertLess(net_returns.mean(), gross_column.mean())
+
+    def test_negative_SR_cost_matches_analytic_expectation(self):
+        # The per-day cost drag applied is a constant:
+        #   (annual_SR_cost / ROOT_BDAYS_INYEAR) * daily_gross_return_std
+        # and, since annual_SR_cost is already signed negative, this
+        # constant must itself be negative (not positive).
+        annual_SR_cost = -0.5
+        dict_of_SR_costs = dictOfSR({"instrument_a": annual_SR_cost})
+
+        net_returns = _adjust_df_column_for_SR_costs(
+            self.gross_returns, dict_of_SR_costs, "instrument_a"
+        )
+
+        gross_column = self.gross_returns["instrument_a"]
+        daily_gross_return_std = gross_column.std()
+        expected_daily_cost = (
+            annual_SR_cost / ROOT_BDAYS_INYEAR
+        ) * daily_gross_return_std
+
+        self.assertLess(expected_daily_cost, 0.0)
+
+        expected_net_returns = gross_column + expected_daily_cost
+        pd.testing.assert_series_equal(
+            net_returns, expected_net_returns, check_names=False
+        )
+
+    def test_zero_SR_cost_leaves_returns_unchanged(self):
+        dict_of_SR_costs = dictOfSR({"instrument_a": 0.0})
+
+        net_returns = _adjust_df_column_for_SR_costs(
+            self.gross_returns, dict_of_SR_costs, "instrument_a"
+        )
+
+        pd.testing.assert_series_equal(
+            net_returns, self.gross_returns["instrument_a"], check_names=False
+        )
+
+    def test_adjust_df_for_SR_costs_reduces_returns_across_all_columns(self):
+        index = self.gross_returns.index
+        np.random.seed(7)
+        gross_returns = pd.DataFrame(
+            {
+                "instrument_a": self.gross_returns["instrument_a"].values,
+                "instrument_b": np.random.normal(loc=0.0, scale=1.2, size=len(index)),
+            },
+            index=index,
+        )
+        dict_of_SR_costs = dictOfSR({"instrument_a": -0.5, "instrument_b": -0.2})
+
+        net_returns_df = _adjust_df_for_SR_costs(gross_returns, dict_of_SR_costs)
+
+        for column_name in gross_returns.columns:
+            self.assertTrue(
+                (net_returns_df[column_name] < gross_returns[column_name]).all()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1644.

## The bug

`_adjust_df_column_for_SR_costs` (`sysquant/returns.py:158-176`) is where `dictOfReturnsForOptimisation.adjust_returns_for_SR_costs` turns a per-asset annualised SR cost into a daily return drag and subtracts it from gross returns. Line 167 was:

```python
daily_returns_cost = -daily_SR_cost * daily_gross_return_std
```

That leading `-` is wrong, and here's the full chain that shows why.

**`dict_of_SR_costs` is already signed negative before it ever reaches this function.** Its values come from `get_annual_SR_dict_for_asset` (`sysquant/returns.py:252-259`) → `get_annual_SR_dict` (`:279-296`) → `_get_annual_SR_for_returns_for_optimisation` (`:313-329`). For `type="costs"`, that last function does:

```python
cost_curve = returns_for_optimisation.costs[column_name]
daily_return = cost_curve.mean()
...
return annual_SR_from_daily_returns(daily_return, daily_std)
```

`annual_SR_from_daily_returns` is just `ROOT_BDAYS_INYEAR * daily_return / daily_std` — it scales, it doesn't flip sign. So the sign of the output SR is the sign of `cost_curve.mean()`.

Follow `cost_curve` back further: `returns_for_optimisation.costs` is `accountCurveGroup.costs` (`systems/accounts/curves/account_curve_group.py:72-80`), which is `pandlCalculationWithGenericCosts.as_pd_series(curve_type=COSTS_CURVE)`. Net P&L is built as `net = gross.add(costs, fill_value=0)` (`systems/accounts/pandl_calculators/pandl_generic_costs.py:60-65, 105-108`) — i.e. the costs curve is *added* to gross to get net, so by construction it already carries a negative sign (a drag). This is confirmed at the source in `pandlCalculationWithSRCosts.SR_cost_as_annualised_figure_points` (`systems/accounts/pandl_calculators/pandl_SR_cost.py:63-72`), which explicitly negates the (positive, magnitude-only) `SR_cost` input before turning it into points: `SR_cost_with_minus_sign = -self.SR_cost`.

So: `dict_of_SR_costs[asset]` is a negative number end to end. `_adjust_df_column_for_SR_costs` divides it by `ROOT_BDAYS_INYEAR` (line 165, still negative) and is then supposed to turn it into a per-day cash/percentage drag by multiplying by `daily_gross_return_std`. Multiplying two things that are already correctly signed (a negative daily cost rate times a positive std) should stay negative and get added onto gross returns to make them net of costs. Instead, line 167 negated it first, turning the drag into a *positive* addition — so `net_returns = gross_returns + daily_returns_cost` came out **higher** than gross returns, i.e. costs looked like they were *helping* performance.

This is also confirmed by the other consumer of the same `dict_of_SR_costs`/cost-SR values, `adjust_dataframe_of_weights_for_SR_costs` in `sysquant/optimisation/SR_adjustment.py:12-29`. It takes `costs_dict[asset]` and feeds it straight into `adjust_dataframe_of_weights_for_SR` as an already-signed SR value with no extra negation — which is the correct handling, and is the pattern `_adjust_df_column_for_SR_costs` should have followed. That code path is untouched by this PR since it isn't affected by the bug.

### Numbers from the issue

Per the report on #1644, for a case with `daily_SR_cost = -0.004988`:
- Before this fix: `daily_returns_cost = +13.85` (cost curve was making net returns look better than gross)
- After this fix: `daily_returns_cost = -13.85` (cost curve correctly drags net returns below gross)

## The fix

Remove the extra negation:

```python
daily_returns_cost = daily_SR_cost * daily_gross_return_std
```

One line changed, no other behaviour touched.

## Tests

Added `sysquant/tests/test_returns.py` (new test module — `sysquant` had no `tests/` package before, so I followed the layout used by `syscore/tests` and `sysquant/estimators/tests`: `unittest.TestCase`, `test_*.py`, `__init__.py`). It covers `_adjust_df_column_for_SR_costs` and its caller `_adjust_df_for_SR_costs`:

- a negative `daily_SR_cost` must strictly reduce every day's net return below the matching gross return (this is the regression test for the bug — it fails against the pre-fix code and passes after)
- the applied daily adjustment matches the analytic expectation `(annual_SR_cost / ROOT_BDAYS_INYEAR) * daily_gross_return_std`, and that value is asserted to be negative
- a zero SR cost leaves returns unchanged (sanity check)
- the dataframe-level wrapper applies the drag independently, correctly, across multiple columns

I also added `sysquant/tests` to the `testpaths` list in `pyproject.toml` so it's picked up by a plain `pytest` run (it wasn't running before since there was no `tests/` directory there).

I manually reverted the one-line fix locally and reran the new tests to confirm 3 of the 4 fail against the old code (the 4th, the zero-cost sanity check, is unaffected by the sign either way) — so the tests do actually catch this regression, not just assert against post-fix behaviour. Full existing suite (`pytest`, with pinned dependency versions from `requirements.txt`) passes: 96 passed, 40 skipped (IB/production-dependent), 5 xfailed. `black --check` is clean on the changed files.

## AI assistance disclosure

Per CONTRIBUTING.md's AI policy: I used Claude (Anthropic) as a research assistant to help locate this call chain across `sysquant/returns.py`, `sysquant/optimisation/SR_adjustment.py`, and the `systems/accounts/pandl_calculators` cost-curve code, and to draft the fix and tests. I independently walked through and verified every step of the sign derivation above against the current source before writing this description — the reasoning here reflects my own understanding of why the costs curve is negative-signed and why the extra negation was wrong, not a pasted AI explanation. I ran the full test suite and the isolated before/after regression check myself, per the policy's requirement that AI-assisted changes be personally reviewed, understood, and tested before submission.
