### PR TITLE
Reject non-finite cost deflators before cash-cost calculation

### DIFF
--- a/syscore/pandas/strategy_functions.py
+++ b/syscore/pandas/strategy_functions.py
@@ -167,7 +167,18 @@ def calculate_cost_deflator(price: pd.Series) -> pd.Series:
     vol_price = daily_returns.rolling(180, min_periods=3).std().ffill()
     final_vol = vol_price.iloc[-1]
 
+    # An all-NaN result means there is not enough history yet; callers already
+    # have their own missing-data policy. A finite zero (or an infinite value)
+    # is different: using it as a denominator creates non-finite cash costs.
+    if not np.isnan(final_vol) and (not np.isfinite(final_vol) or final_vol <= 0):
+        raise ValueError(
+            "Cost deflator cannot use a non-positive or infinite terminal volatility"
+        )
+
     cost_scalar = vol_price / final_vol
+
+    if not np.isfinite(cost_scalar.dropna()).all():
+        raise ValueError("Cost deflator contains non-finite values")
 
     return cost_scalar
 

--- a/syscore/tests/test_strategy_functions.py
+++ b/syscore/tests/test_strategy_functions.py
@@ -1,0 +1,41 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from syscore.pandas.strategy_functions import calculate_cost_deflator
+
+
+class TestCostDeflator(unittest.TestCase):
+    def test_valid_prices_produce_finite_deflator(self):
+        index = pd.bdate_range("2020-01-01", periods=300)
+        daily_moves = 0.2 + np.sin(np.arange(len(index)) / 7.0)
+        prices = pd.Series(100.0 + np.cumsum(daily_moves), index=index)
+
+        deflator = calculate_cost_deflator(prices)
+
+        self.assertEqual(deflator.iloc[-1], 1.0)
+        self.assertTrue(np.isfinite(deflator.dropna()).all())
+
+    def test_flat_terminal_window_is_rejected(self):
+        index = pd.bdate_range("2020-01-01", periods=500)
+        changing_prices = np.linspace(100.0, 120.0, 120)
+        flat_prices = np.full(len(index) - len(changing_prices), changing_prices[-1])
+        prices = pd.Series(
+            np.concatenate([changing_prices, flat_prices]), index=index
+        )
+
+        with self.assertRaisesRegex(ValueError, "terminal volatility"):
+            calculate_cost_deflator(prices)
+
+    def test_insufficient_history_remains_missing(self):
+        index = pd.bdate_range("2020-01-01", periods=2)
+        prices = pd.Series([100.0, 101.0], index=index)
+
+        deflator = calculate_cost_deflator(prices)
+
+        self.assertTrue(deflator.isna().all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR draft

## Title

Reject non-finite cost deflators before cash-cost calculation

## Body

### What changed

`calculate_cost_deflator()` now rejects a zero, negative, or infinite terminal
volatility before using it as a denominator. It also verifies that all non-NaN
values in the resulting deflator are finite.

An all-NaN volatility caused by insufficient history is intentionally preserved
so existing caller-specific missing-data policies continue to work.

### Why

If the last 180 business-day price changes are constant, terminal rolling
volatility can be zero. Dividing historical volatility by that value produces
`+inf` cost deflators. Downstream cash-cost accounting can then produce
non-finite costs and P&L instead of failing at the source of the invalid input.

Failing explicitly prevents non-finite values from propagating into accounting,
portfolio analytics, and any consumers of subsystem P&L.

### Tests

Added regression coverage for:

- a normal varying price series, which produces a finite deflator ending at
  `1.0`;
- a moving series followed by a flat terminal window, which now raises before
  division;
- an insufficient-history series, which preserves the existing all-NaN result.

Targeted verification:

```text
9 passed
```

The public-safe synthetic incident reproducer now stops at
`calculate_cost_deflator()` with a descriptive `ValueError`, before any
infinite cost or P&L value is created.

### Scope

This PR does not alter volatility estimation, position sizing, instrument
admission, order generation, or any dashboard/research code.
