### PR TITLE
Add opt-in price-history eligibility controls to volatility estimators

### DIFF
--- a/sysquant/estimators/tests/test_vol.py
+++ b/sysquant/estimators/tests/test_vol.py
@@ -1,0 +1,83 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from sysquant.estimators.vol import (
+    apply_price_history_eligibility,
+    mixed_vol_calc,
+)
+
+
+class TestPriceHistoryEligibility(unittest.TestCase):
+    def setUp(self):
+        self.index = pd.bdate_range("2024-01-01", periods=12)
+        self.vol = pd.Series(2.0, index=self.index)
+
+    def test_controls_are_disabled_by_default(self):
+        returns = pd.Series(0.0, index=self.index)
+
+        actual = apply_price_history_eligibility(self.vol, returns)
+
+        self.assertIs(actual, self.vol)
+
+    def test_minimum_nonzero_changes_masks_early_history(self):
+        returns = pd.Series(
+            [np.nan, 0.0, 1.0, 0.0, -1.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            index=self.index,
+        )
+
+        actual = apply_price_history_eligibility(
+            self.vol, returns, min_nonzero_price_changes=3
+        )
+
+        self.assertTrue(actual.iloc[:6].isna().all())
+        self.assertTrue(actual.iloc[6:].eq(2.0).all())
+
+    def test_unchanged_streak_masks_until_prices_move_again(self):
+        returns = pd.Series(
+            [1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0],
+            index=self.index,
+        )
+
+        actual = apply_price_history_eligibility(
+            self.vol, returns, max_consecutive_unchanged_days=2
+        )
+
+        self.assertTrue(np.isnan(actual.iloc[3]))
+        self.assertEqual(actual.iloc[4], 2.0)
+        self.assertTrue(actual.iloc[7:9].isna().all())
+        self.assertEqual(actual.iloc[9], 2.0)
+
+    def test_invalid_limits_raise(self):
+        returns = pd.Series(0.0, index=self.index)
+
+        with self.assertRaises(ValueError):
+            apply_price_history_eligibility(
+                self.vol, returns, min_nonzero_price_changes=-1
+            )
+        with self.assertRaises(ValueError):
+            apply_price_history_eligibility(
+                self.vol, returns, max_consecutive_unchanged_days=-1
+            )
+
+    def test_mixed_vol_backfill_does_not_bypass_minimum_changes(self):
+        index = pd.bdate_range("2024-01-01", periods=40)
+        returns = pd.Series(
+            [0.0] * 12 + [1.0, -1.0, 2.0] + [0.5, -0.5] * 12 + [0.25],
+            index=index,
+        )
+
+        actual = mixed_vol_calc(
+            returns,
+            min_periods=2,
+            backfill=True,
+            min_nonzero_price_changes=3,
+        )
+
+        self.assertTrue(actual.iloc[:14].isna().all())
+        self.assertTrue(np.isfinite(actual.iloc[14:]).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sysquant/estimators/vol.py
+++ b/sysquant/estimators/vol.py
@@ -24,6 +24,8 @@ def robust_vol_calc(
     floor_min_periods: int = 100,
     floor_days: int = 500,
     backfill: bool = False,
+    min_nonzero_price_changes: int = 0,
+    max_consecutive_unchanged_days: int | None = None,
     **ignored_kwargs,
 ) -> pd.Series:
     """
@@ -78,6 +80,13 @@ def robust_vol_calc(
         # use the first vol in the past, sort of cheating
         vol = backfill_vol(vol)
 
+    vol = apply_price_history_eligibility(
+        vol,
+        daily_returns,
+        min_nonzero_price_changes=min_nonzero_price_changes,
+        max_consecutive_unchanged_days=max_consecutive_unchanged_days,
+    )
+
     return vol
 
 
@@ -118,6 +127,49 @@ def backfill_vol(vol: pd.Series) -> pd.Series:
     return vol_backfilled
 
 
+def apply_price_history_eligibility(
+    vol: pd.Series,
+    daily_returns: pd.Series,
+    min_nonzero_price_changes: int = 0,
+    max_consecutive_unchanged_days: int | None = None,
+) -> pd.Series:
+    """Mask volatility where the observed price history is not yet usable.
+
+    Both controls are opt-in so existing configurations retain their current
+    behaviour. Applying the mask after any volatility backfill ensures that a
+    backfilled estimate cannot make an instrument eligible before its prices
+    have actually varied.
+    """
+    if min_nonzero_price_changes < 0:
+        raise ValueError("min_nonzero_price_changes must be non-negative")
+    if (
+        max_consecutive_unchanged_days is not None
+        and max_consecutive_unchanged_days < 0
+    ):
+        raise ValueError("max_consecutive_unchanged_days must be non-negative")
+
+    if (
+        min_nonzero_price_changes == 0
+        and max_consecutive_unchanged_days is None
+    ):
+        return vol
+
+    aligned_returns = daily_returns.reindex(vol.index)
+    observed = aligned_returns.notna()
+    changed = observed & aligned_returns.ne(0.0)
+    eligible = pd.Series(True, index=vol.index)
+
+    if min_nonzero_price_changes > 0:
+        eligible &= changed.cumsum() >= min_nonzero_price_changes
+
+    if max_consecutive_unchanged_days is not None:
+        unchanged = observed & aligned_returns.eq(0.0)
+        unchanged_streak = unchanged.groupby((~unchanged).cumsum()).cumsum()
+        eligible &= unchanged_streak <= max_consecutive_unchanged_days
+
+    return vol.where(eligible)
+
+
 def mixed_vol_calc(
     daily_returns: pd.Series,
     days: int = 35,
@@ -126,6 +178,8 @@ def mixed_vol_calc(
     proportion_of_slow_vol: float = 0.3,
     vol_abs_min: float = 0.0000000001,
     backfill: bool = False,
+    min_nonzero_price_changes: int = 0,
+    max_consecutive_unchanged_days: int | None = None,
     **ignored_kwargs,
 ) -> pd.Series:
     """
@@ -177,6 +231,13 @@ def mixed_vol_calc(
     if backfill:
         # use the first vol in the past, sort of cheating
         vol = backfill_vol(vol)
+
+    vol = apply_price_history_eligibility(
+        vol,
+        daily_returns,
+        min_nonzero_price_changes=min_nonzero_price_changes,
+        max_consecutive_unchanged_days=max_consecutive_unchanged_days,
+    )
 
     return vol
 


### PR DESCRIPTION
# PR draft

## Title

Add opt-in price-history eligibility controls to volatility estimators

## Body

### What changed

`robust_vol_calc()` and `mixed_vol_calc()` now accept two optional controls:

- `min_nonzero_price_changes`, default `0`;
- `max_consecutive_unchanged_days`, default `None`.

After the existing volatility calculation and optional backfill, the estimator
masks volatility until the configured minimum number of real price changes has
been observed. It also masks volatility while a configured consecutive
unchanged-price streak is exceeded, and automatically restores eligibility
after the price moves again.

Both controls are disabled by default, preserving current upstream behavior.

### Why

A short or stale price history can be reduced to the existing absolute
volatility floor before there is enough empirical information to size a futures
position. Downstream position sizing can then treat a numerical floor as if it
were an economically meaningful estimate.

These opt-in controls let users express price-history eligibility at the
volatility boundary without changing the numerical floor itself and without
hard-coding one policy for every deployment.

### Tests

Regression tests cover:

- unchanged default behavior when both controls are disabled;
- masking until enough non-zero price changes exist;
- masking during an excessive unchanged-price streak and restoring eligibility
  after a subsequent price move;
- ensuring backfill cannot bypass eligibility;
- rejection of negative configuration values.

### Compatibility and scope

The patch changes no default config and has no effect unless a caller opts in.
It does not add order limits, connect to a broker, alter accounting, or impose a
global instrument-admission policy. It provides a reusable estimator-level
signal that existing system stages can propagate naturally as missing
volatility until the history is eligible.
